### PR TITLE
feat: port full performance-tuned automation runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .idea/
 __pycache__/
+.pytest_cache/
+.dsh-shots/
 venv/
 .venv/
 .venv-release/

--- a/FSM_action.py
+++ b/FSM_action.py
@@ -6,8 +6,6 @@ import time
 
 import keyboard
 
-import requests
-
 import click
 import get_screen
 from manual_controller import (
@@ -28,7 +26,6 @@ from src.recommendation_config import RecommendationConfig
 from src.recommendation_models import ActionKind
 from src.safety.recommendation_validator import RecommendationValidator
 
-from datetime import datetime
 
 FSM_state = ""
 time_begin = 0.0
@@ -53,6 +50,7 @@ recommendation_config = None
 recommendation_capture = None
 recommendation_parser = None
 recommendation_reader = None
+mulligan_reader = None
 recommendation_validator = None
 active_game_generation = -1
 mulligan_delay_generation = None
@@ -80,26 +78,50 @@ def _automation_state_with_revision():
 
 
 def initialize_recommendation_automation():
-    """Rebuild per-game flows while reusing expensive OCR components."""
+    """Rebuild per-game flows while reusing expensive OCR components.
+
+    每次调用都会重新读取 ui_config.json 的 recommendation_roi（重建轻量的
+    RecommendationConfig + DesktopCapture），因此用校准工具画完框后，直接重开
+    对局/重启自动化即可生效，无需重启 web_ui。昂贵的 OCR 引擎（reader 与
+    paddle backend）仍只创建一次、跨对局复用。
+    """
     global auto_mulligan_flow, recommendation_flow
     global recommendation_config, recommendation_capture
     global recommendation_parser, recommendation_reader
-    global recommendation_validator
+    global mulligan_reader, recommendation_validator
 
-    if recommendation_config is None:
-        recommendation_config = RecommendationConfig()
-        recommendation_capture = DesktopCapture(recommendation_config)
+    # 轻量：每次都重建，以便拾取校准后的最新 ROI / 尺寸配置。
+    recommendation_config = RecommendationConfig()
+    recommendation_capture = DesktopCapture(recommendation_config)
+
+    if recommendation_parser is None:
         recommendation_parser = RecommendationParser()
+
+    if recommendation_reader is None:
         recommendation_reader = StableRecommendationReader(
             recommendation_config, PaddleOcrAdapter(),
-            text_normalizer=recommendation_parser.normalize_action_text,
-            required_headers=("打法参考A", "打法参考Ａ"))
+            text_normalizer=recommendation_parser.normalize_action_text)
+        # 不设"打法参考A"信标：对战时该标题不在截图区域内（实测
+        # 面板直出「打出N号位…」指令文本），设信标会把正确指令清空为
+        # recommendation_not_stable 死循环。面板是否在场由 parser
+        # 严格句式（打出N号位随从/放置于我方N号位 等）唯一把关，
+        # 与换牌 reader 同一设计。
+    if mulligan_reader is None:
+        # 换牌面板只有留牌建议（无"打法参考A"标题）：不设信标，
+        # 面板是否在场由 `替换N号位卡牌` 换牌句式唯一把关。
+        # 独立 if 保证每次 initialize（含 config 已存在的后续对局）
+        # 都会为闭包绑定该变量。
+        mulligan_reader = StableRecommendationReader(
+            recommendation_config, recommendation_reader.backend,
+            text_normalizer=recommendation_parser.normalize_action_text)
         recommendation_validator = RecommendationValidator(
             recommendation_config)
 
     def read_mulligan_action():
-        evidence = recommendation_reader.read(
-            recommendation_capture.capture,
+        # 换牌面板是否在场，由 OCR 证据裁定：识别出的文本必须能解析出
+        # `替换N号位卡牌` 换牌句式（无"打法参考A"信标的专用 reader）。
+        evidence = mulligan_reader.read(
+            lambda: recommendation_capture.capture(ocr_panel_ok=True),
             recommendation_capture.crop_recommendation)
         action = recommendation_parser.parse(
             evidence, log_state.game_num_turns_in_play, log_state.revision)
@@ -110,7 +132,9 @@ def initialize_recommendation_automation():
     auto_mulligan_flow = MulliganFlow(
         click, read_mulligan_action, _automation_state,
         action_context=click.hearthstone_action_session,
-        stopped=shutdown_event.is_set)
+        stopped=shutdown_event.is_set,
+        first_delay=recommendation_config.mulligan_ready_delay_seconds,
+        retry_delay=recommendation_config.mulligan_post_ocr_delay_seconds)
     recommendation_flow = RecommendationFlow(
         capture=recommendation_capture,
         reader=recommendation_reader,
@@ -120,6 +144,7 @@ def initialize_recommendation_automation():
         validator=recommendation_validator,
         controller=manual_controller,
         result_timeout=recommendation_config.result_timeout_seconds,
+        post_action_delay=recommendation_config.post_action_delay_seconds,
         stopped=shutdown_event.is_set,
     )
 
@@ -232,42 +257,8 @@ def wait_until_battle_starts():
         time.sleep(STATE_CHECK_INTERVAL)
 
 
-def push_wx(sckey, desp=""):
-    """
-    推送消息到微信
-    """
-    if sckey == '':
-        print("[注意] 未提供sckey，不进行推送！")
-    else:
-        server_url = f"https://sc.ftqq.com/{sckey}.send"
-        params = {
-            "text": '小米运动 步数修改',
-            "desp": desp
-        }
-
-        response = requests.get(server_url, params=params)
-        json_data = response.json()
-
-        if json_data['data']['errno'] == 0:
-            print("{}, {}点，推送成功".format(datetime.now().date(), datetime.now().hour))
-        else:
-            print("{}, {}点，推送失败，{}，{}".format(datetime.now().date(), datetime.now().hour, json_data['data']['errno'],
-                                              json_data['data']['errmsg']))
-            # print(f"[{datetime.now().date()}] 推送失败：{json_data['data']['errno']}({json_data['data']['errmsg']})")
-
-
 def system_exit():
     global quitting_flag
-
-    sckey = ""
-    # 这个码是推送信息到微信的码，去sct.ftqq.com上绑定，不需要就不用管
-
-    push = f"一共完成了{game_count}场对战, 赢了{win_count}场"
-
-    try:
-        push_wx(sckey, push)
-    except:
-        print("无法推送")
 
     sys_print(f"一共完成了{game_count}场对战, 赢了{win_count}场")
     print_info_close()
@@ -377,8 +368,16 @@ def MatchingAction():
             return FSM_ERROR
 
 
+def _mulligan_hand_identity(snapshot):
+    """换牌期手牌指纹：换牌点击生效后（手牌变化）指纹改变。"""
+    return tuple(
+        (getattr(card, "card_id", None), getattr(card, "entity_id", None))
+        for card in getattr(snapshot, "my_hand_cards", ()))
+
+
 def ChoosingCardAction():
     global choose_hero_count, mulligan_delay_generation
+    global quitting_flag, stop_after_current_game, shutdown_event
     choose_hero_count = 0
 
     print_out()
@@ -407,12 +406,51 @@ def ChoosingCardAction():
             return FSM_BATTLING
 
     if auto_mulligan_flow is not None:
-        result = auto_mulligan_flow.run()
-        if result.status == MulliganStatus.CONFIRMED:
-            return wait_until_battle_starts()
-        manual_controller.output(
-            f"换牌推荐暂不可执行，继续重试：{result.diagnostics}")
-        return FSM_CHOOSING_CARD
+        auto_mulligan_flow.reset_delay()  # 每局首次用 ready(7)，重试用 post_ocr(5)
+        # 换牌操作不断重复执行，直至回合开始：
+        # - 识别/执行失败 → 立即重试（原重试机制不变）
+        # - 点击完成但手牌未变（点击未生效）→ 重新尝试
+        # - 确认生效后 → 快速轮询直到对局进入战斗回合
+        initial_hand = _mulligan_hand_identity(snapshot)
+        confirmed_waiting = False
+        confirmed_hand = None
+        while True:
+            # 循环内必须检查停止标志：主循环只在状态分发处检查，
+            # 本循环若能无限运行，定时停止后鼠标会继续点击。
+            if quitting_flag:
+                sys.exit(0)
+            if stop_after_current_game:
+                info_print("已到计划停止时间，自动化停止。")
+                quitting_flag = True
+                shutdown_event.set()
+                sys.exit(0)
+            fresh = refresh_snapshot()
+            if fresh is None:
+                return FSM_ERROR
+            if fresh.is_end:
+                return FSM_QUITTING_BATTLE
+            if fresh.game_num_turns_in_play > 0:
+                return FSM_BATTLING
+            if confirmed_waiting:
+                cur_hand = _mulligan_hand_identity(fresh)
+                if cur_hand != confirmed_hand:
+                    # 换牌已生效，等待对局开始
+                    time.sleep(0.3)
+                    continue
+                manual_controller.output(
+                    "换牌点击未生效（手牌未变），重新尝试……")
+                confirmed_waiting = False
+            result = auto_mulligan_flow.run()
+            if result.status == MulliganStatus.CONFIRMED:
+                confirmed_waiting = True
+                confirmed_hand = _mulligan_hand_identity(
+                    refresh_snapshot() or fresh)
+                manual_controller.output("已执行换牌，等待确认……")
+                time.sleep(0.3)
+                continue
+            manual_controller.output(
+                f"换牌推荐暂不可执行，继续重试：{result.diagnostics}")
+            time.sleep(0.3)
 
     selected = manual_controller.choose_mulligan(snapshot)
     fresh_snapshot = refresh_snapshot()
@@ -491,7 +529,22 @@ def run_automatic_battle_step():
         return FSM_QUITTING_BATTLE
     if not snapshot.is_my_turn:
         _report_automation_diagnostic("opponent_turn", "等待对手操作。")
+        # 对方回合清空延迟标记：每次切回我方回合必延时一次，
+        # 同回合内多次出牌不再重复延时（不依赖可能失真的回合号）。
+        player_turn_delay_key = None
         return None
+    _report_automation_diagnostic("my_turn", "轮到己方操作：开始读取推荐……")
+    turn = snapshot.game_num_turns_in_play
+    if player_turn_delay_key != turn:
+        # 每个新回合开始只延时一次（给盒子更新推荐留时间），
+        # 同回合内的多次出牌操作之间不重复延时。
+        player_turn_delay_key = turn
+        manual_controller.output(
+            f"[SYS] 回合 {turn} 开始：延时 "
+            f"{recommendation_config.pre_action_delay_seconds:.0f}s 后开始 OCR……")
+        time.sleep(recommendation_config.pre_action_delay_seconds)
+        manual_controller.output(
+            f"[SYS] 回合 {turn} 延时结束，开始本轮推荐读取。")
     if recommendation_flow is None:
         return run_manual_battle_step()
 

--- a/config.py
+++ b/config.py
@@ -1,0 +1,85 @@
+"""用户/站点/机器级配置的单一来源（分层合并）。
+
+三个来源，优先级从低到高：
+
+    1. 内置默认值（本文件）
+    2. ui_config.json —— Web 控制台 / 校准工具持久化的用户配置
+    3. 环境变量 —— 机器 / 高级覆盖（如 HS_LOG_ROOT、HS_USER_NAME、HS_PORT）
+
+约定：
+    * 本模块只做"解析站点/用户/机器配置"，不含业务逻辑。
+    * 其他模块直接 `from config import ...` 或 `import config` 取值，
+      不要再在代码里写死机器路径/用户身份。
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+CONFIG_PATH = ROOT / "ui_config.json"
+
+_env = os.environ.get
+
+
+def _load_ui_config() -> dict:
+    """读取 ui_config.json；缺失/非法时返回空 dict（走默认值）。"""
+    try:
+        data = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+_UI = _load_ui_config()
+
+
+def _first(*values, default=""):
+    """返回第一个非空值，用于默认值回退。"""
+    for value in values:
+        if value not in (None, "", 0):
+            return value
+    return default
+
+
+# ---------------------------------------------------------------- 用户身份
+# 环境变量 HS_USER_NAME > ui_config.json 的 name > 占位默认。
+USER_NAME = _first(_env("HS_USER_NAME"), _UI.get("name"), "YOURNAME#1234")
+
+# ---------------------------------------------------------------- 炉石日志根目录
+_LOCALAPPDATA_BLIZZARD = os.path.join(
+    os.environ.get("LOCALAPPDATA", ""), "Blizzard", "Hearthstone", "Logs")
+
+
+def _resolve_log_root() -> str:
+    """环境变量 HS_LOG_ROOT > ui_config.json 的 log_root > LOCALAPPDATA 自动探测。"""
+    candidates = (
+        _env("HS_LOG_ROOT"),
+        _UI.get("log_root"),
+        _LOCALAPPDATA_BLIZZARD if os.path.isdir(_LOCALAPPDATA_BLIZZARD) else "",
+    )
+    for cand in candidates:
+        if cand and os.path.isdir(cand):
+            return cand
+    # 都不存在：返回配置值/空串，交由调用方处理（web 会提示用户填写）。
+    return _first(_env("HS_LOG_ROOT"), _UI.get("log_root"))
+
+
+HEARTHSTONE_LOG_ROOT = _resolve_log_root()
+
+# ---------------------------------------------------------------- Web 控制台
+HOST = _env("HS_HOST", "127.0.0.1")
+BASE_PORT = int(_env("HS_PORT", "8765"))
+LOG_BUFFER_SIZE = int(_env("HS_LOG_BUFFER_SIZE", "500"))
+
+# ---------------------------------------------------------------- 操作节奏（环境变量可覆盖）
+OPERATE_INTERVAL = float(_env("HS_OPERATE_INTERVAL", "0.15"))
+STATE_CHECK_INTERVAL = float(_env("HS_STATE_CHECK_INTERVAL", "1.0"))
+TINY_OPERATE_INTERVAL = float(_env("HS_TINY_OPERATE_INTERVAL", "0.08"))
+
+# ---------------------------------------------------------------- OCR 模型目录
+# 环境变量 HS_OCR_MODEL_ROOT > %LOCALAPPDATA%/AutoHS/ocr_models/paddleocr。
+OCR_MODEL_ROOT = os.environ.get("HS_OCR_MODEL_ROOT") or os.path.normpath(
+    os.path.join(os.environ.get("LOCALAPPDATA", os.path.expanduser("~")),
+                 "AutoHS", "ocr_models", "paddleocr"))

--- a/constants/constants.py
+++ b/constants/constants.py
@@ -1,10 +1,13 @@
-# 炉石日志根目录。脚本会自动选择最新的
-# Hearthstone_YYYY_MM_DD_HH_MM_SS/Power.log。
-HEARTHSTONE_LOG_ROOT = "D:/Hearthstone/Logs"
+# 用户身份与炉石日志目录已迁移到 config.py（分层：内置默认 < ui_config.json < 环境变量）。
+# 这里是唯一的转发点，避免在多处硬编码机器路径/用户身份。
+from config import (
+    HEARTHSTONE_LOG_ROOT, USER_NAME,
+    OPERATE_INTERVAL, STATE_CHECK_INTERVAL, TINY_OPERATE_INTERVAL,
+)
 
 # 你的炉石用户名, 注意英文标点符号'#', 把后面的数字也带上
 # 可以输入中文
-YOUR_NAME = "YOURNAME#1234"
+YOUR_NAME = USER_NAME
 
 # 关于控制台信息打印的设置
 DEBUG_PRINT = True
@@ -19,10 +22,6 @@ WARN_FILE_WRITE = True
 SYS_FILE_WRITE = True
 INFO_FILE_WRITE = True
 ERROR_FILE_WRITE = True
-
-OPERATE_INTERVAL = 0.2
-STATE_CHECK_INTERVAL = 1
-TINY_OPERATE_INTERVAL = 0.1
 
 # 我觉得这行注释之后的内容应该不需要修改……
 FSM_LEAVE_HS = "Leave Hearth Stone"

--- a/get_screen.py
+++ b/get_screen.py
@@ -179,7 +179,7 @@ def catch_screen(name=None, frame_grabber=None):
     win32gui.DeleteObject(saveBitMap.GetHandle())
     saveDC.DeleteDC()
     mfcDC.DeleteDC()
-    win32gui.ReleaseDC(hwnd, hwndDC)
+    win32gui.ReleaseDC(hwin, hwndDC)
 
     im_opencv = numpy.frombuffer(signedIntsArray, dtype='uint8')
     im_opencv.shape = (height, width, 4)

--- a/json_op.py
+++ b/json_op.py
@@ -1,13 +1,20 @@
-import requests
 import json
 import os
+
+import requests
+
 from print_info import *
 
 
 # 来源于互联网的炉石JSON数据下载API, 更多信息可以访问 https://hearthstonejson.com/
+JSON_URL = "https://api.hearthstonejson.com/v1/latest/zhCN/cards.json"
+# 下载/重下载都设超时，避免主循环被网络卡死。
+DOWNLOAD_TIMEOUT_SECONDS = 30
+
+
 def download_json(json_path):
-    json_url = "https://api.hearthstonejson.com/v1/latest/zhCN/cards.json"
-    file = requests.get(json_url)
+    file = requests.get(JSON_URL, timeout=DOWNLOAD_TIMEOUT_SECONDS)
+    file.raise_for_status()
 
     with open(json_path, "wb") as f:
         f.write(file.content)
@@ -37,26 +44,49 @@ def read_json(re_download=False):
         return json_dict
 
 
+# 懒加载：首次 query 时才读取（cards.json 缺失时首次会联网下载一次）。
+# 原先在模块导入时同步联网，无网/CI 环境会卡在 import。
+JSON_DICT = {}
+_load_attempted = False
+# 未知卡牌触发"重新下载最新数据"最多一次（本次会话），
+# 避免主循环里每遇到一张新卡就反复全量下载。
+_reload_attempted = False
+
+
 def query_json_dict(key):
-    global JSON_DICT
+    global JSON_DICT, _load_attempted, _reload_attempted
 
     if key == "":
         return "Unknown"
 
+    if not _load_attempted:
+        _load_attempted = True
+        try:
+            JSON_DICT = read_json(re_download=False)
+        except Exception as exc:
+            error_print(f"加载卡牌数据失败：{type(exc).__name__}: {exc}")
+            JSON_DICT = {}
+
     if key in JSON_DICT:
         return JSON_DICT[key]["name"]
-    # 认为是炉石更新了，出现了新卡，需要重新下载。
-    else:
-        JSON_DICT = read_json(True)
-        if key not in JSON_DICT:
-            error_print(f"出现未识别卡牌，使用占位名称继续：{key}")
-            return f"Unknown:{key}"
-        return JSON_DICT[key]["name"]
 
+    # 认为是炉石更新了，出现了新卡，需要重新下载一次；
+    # 若重下载后仍没有，就用占位名继续，且本次会话不再尝试。
+    if not _reload_attempted:
+        _reload_attempted = True
+        try:
+            JSON_DICT = read_json(re_download=True)
+        except Exception as exc:
+            error_print(f"重新下载卡牌数据失败：{type(exc).__name__}: {exc}")
+        if key in JSON_DICT:
+            return JSON_DICT[key]["name"]
 
-JSON_DICT = read_json()
+    error_print(f"出现未识别卡牌，使用占位名称继续：{key}")
+    return f"Unknown:{key}"
+
 
 if __name__ == "__main__":
+    JSON_DICT = read_json()
     with open("id-name.txt", "w", encoding="utf8") as f:
         for key, val in JSON_DICT.items():
             f.write(key + " " + val["name"] + "\n")

--- a/main.py
+++ b/main.py
@@ -1,7 +1,6 @@
 from time import sleep
 from FSM_action import system_exit, AutoHS_automata
 import keyboard
-from log_state import check_name
 from print_info import print_info_init
 from FSM_action import init
 
@@ -16,11 +15,8 @@ if __name__ == "__main__":
     print("按 Ctrl+Q 可随时停止自动化并退出程序")
     
     MY_NAME = constants.constants.YOUR_NAME
-    HEARTHSTONE_LOG_ROOT = constants.constants.HEARTHSTONE_LOG_ROOT
-    #input("请确认你的用户名为："+MY_NAME+"。炉石日志目录为："+HEARTHSTONE_LOG_ROOT+"（确认完成后请回车）")
     print("你好"+MY_NAME)
     sleep(2)
-    # check_name()
     print_info_init()
     init()
     keyboard.add_hotkey("ctrl+q", system_exit)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 click==8.4.2
 keyboard==0.13.5
 numpy==2.5.2
-opencv_contrib_python==4.10.0.84
-opencv_python==4.10.0.84
 opencv_python_headless==4.10.0.84
 paddleocr==2.10.0
 paddlepaddle==2.6.2

--- a/src/capture/desktop_capture.py
+++ b/src/capture/desktop_capture.py
@@ -104,7 +104,7 @@ class DesktopCapture:
             raise CaptureEnvironmentError("frame_decode_failed")
         return self.from_array(pixels, validate_environment=False)
 
-    def capture(self) -> FrameEvidence:
+    def capture(self, ocr_panel_ok: bool = False) -> FrameEvidence:
         if not self.process_checker():
             raise CaptureEnvironmentError("required_process_missing")
         hwnd, foreground = self.window_reader()
@@ -113,9 +113,22 @@ class DesktopCapture:
         if not foreground:
             raise CaptureEnvironmentError("hearthstone_not_foreground")
         pixels = self.screen_grabber()
-        return self.from_array(
-            pixels, validate_environment=True, dpi=self.dpi_reader(),
-            window_handle=hwnd, foreground=foreground)
+        try:
+            return self.from_array(
+                pixels, validate_environment=True, dpi=self.dpi_reader(),
+                window_handle=hwnd, foreground=foreground)
+        except CaptureEnvironmentError as exc:
+            if "recommendation_panel_missing" not in str(exc):
+                raise
+            if not ocr_panel_ok:
+                raise
+            # 换牌面板的红头判定并不可靠；交由 OCR 证据裁定：
+            # 识别出"打法参考A"（stable_reader.required_headers）即确认
+            # 面板在，否则由 reader 置零置信度拒绝，安全兜底。
+            return self.from_array(
+                pixels, validate_environment=False, dpi=self.dpi_reader(),
+                window_handle=hwnd, foreground=foreground)
+
 
     def from_array(
         self,

--- a/src/flow/mulligan_flow.py
+++ b/src/flow/mulligan_flow.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from enum import Enum
+import time
 
 
 class MulliganStatus(str, Enum):
@@ -18,11 +19,17 @@ class MulliganResult:
 
 class MulliganFlow:
     def __init__(self, executor, action_supplier, state_supplier,
-                 action_context=None, stopped=lambda: False):
+                 action_context=None, stopped=lambda: False,
+                 sleep=time.sleep, pre_action_delay=5.0,
+                 first_delay=None, retry_delay=None):
         self.executor = executor
         self.action_supplier = action_supplier
         self.state_supplier = state_supplier
         self.stopped = stopped
+        self.sleep = sleep
+        self.first_delay = first_delay if first_delay is not None else pre_action_delay
+        self.retry_delay = retry_delay if retry_delay is not None else pre_action_delay
+        self._delay_done = False
         if action_context is None:
             from contextlib import nullcontext
             action_context = nullcontext
@@ -61,6 +68,10 @@ class MulliganFlow:
                     for index in selected):
                 return MulliganResult(MulliganStatus.CONCEDE,
                                       diagnostics="mulligan_slot_invalid")
+            delay = self.retry_delay if self._delay_done else self.first_delay
+            print(f"已识别换牌建议，等待 {delay:.0f}s 后执行……")
+            self.sleep(delay)
+            self._delay_done = True
             with self.action_context():
                 for index in selected:
                     self.executor.replace_starting_card(index, count)
@@ -74,6 +85,10 @@ class MulliganFlow:
             return MulliganResult(
                 MulliganStatus.CONCEDE,
                 diagnostics=f"{type(exc).__name__}:{exc}")
+
+    def reset_delay(self):
+        """每局换牌开始时调用：首次用 ready_delay，重试用 retry_delay。"""
+        self._delay_done = False
 
     @staticmethod
     def _identity(state):

--- a/src/flow/recommendation_flow.py
+++ b/src/flow/recommendation_flow.py
@@ -30,7 +30,7 @@ class RecommendationFlow:
     def __init__(self, capture, reader, parser, state_supplier, adapter,
                  validator, controller, sleep=time.sleep, clock=time.time,
                  result_timeout=5.0, stopped=lambda: False,
-                 consumed=None):
+                 consumed=None, post_action_delay=0.0):
         self.capture = capture
         self.reader = reader
         self.parser = parser
@@ -45,6 +45,7 @@ class RecommendationFlow:
         self.result_timeout = result_timeout
         self.stopped = stopped
         self.consumed = consumed or ConsumedActionStore()
+        self.post_action_delay = post_action_delay
         self.waiting_instruction = None
         self.waiting_panel_hash = None
         self.waiting_turn_number = None
@@ -61,7 +62,7 @@ class RecommendationFlow:
                 self._clear_waiting()
             observed = {}
             def frame_supplier():
-                observed["frame"] = self.capture.capture()
+                observed["frame"] = self.capture.capture(ocr_panel_ok=True)
                 return observed["frame"]
             evidence = self.reader.read(
                 frame_supplier, self.capture.crop_recommendation)
@@ -76,7 +77,7 @@ class RecommendationFlow:
                     "stale_mulligan_recommendation")
             adapted = self.adapter(proposed, state)
             fresh_state, fresh_revision = self.state_supplier()
-            current_frame = self.capture.capture()
+            current_frame = self.capture.capture(ocr_panel_ok=True)
             current_evidence = self.reader.read_frame(
                 current_frame, self.capture.crop_recommendation)
             if (current_evidence.normalized_text
@@ -91,10 +92,14 @@ class RecommendationFlow:
             if not validation.accepted:
                 return FlowStepResult(FlowStepStatus.RETRY, validation.code)
             adapted, key = validation.value
+            print(f"[推荐] {proposed.normalized_instruction}")
+            print("[执行] 开始点击。")
             result = self.controller.execute(adapted.manual_action, fresh_state)
             if not result.executed or result.recovery_needed:
                 return FlowStepResult(FlowStepStatus.RETRY,
                                       "execution_failed")
+            # 操作结束后延时再开始下一轮截图+OCR（盒子更新面板留时间）。
+            self.sleep(self.post_action_delay)
             verified = self._verify_result(
                 proposed, adapted, current_frame,
                 fresh_state, fresh_revision)
@@ -152,7 +157,7 @@ class RecommendationFlow:
                            adapted.target_entity_id))
         recommendation_changed = False
         try:
-            after_frame = self.capture.capture()
+            after_frame = self.capture.capture(ocr_panel_ok=True)
             if after_frame.exact_hash != before_frame.exact_hash:
                 supplied = False
                 def frame_supplier():
@@ -160,7 +165,7 @@ class RecommendationFlow:
                     if not supplied:
                         supplied = True
                         return after_frame
-                    return self.capture.capture()
+                    return self.capture.capture(ocr_panel_ok=True)
                 after_evidence = self.reader.read(
                     frame_supplier, self.capture.crop_recommendation)
                 recommendation_changed = (

--- a/src/ocr/paddle_adapter.py
+++ b/src/ocr/paddle_adapter.py
@@ -1,5 +1,6 @@
 """Lazy PaddleOCR boundary with normalized evidence output."""
 
+import cv2
 import importlib.machinery
 import importlib.util
 import os
@@ -7,11 +8,33 @@ from pathlib import Path
 import sys
 import time
 
+from src.recommendation_config import RecommendationConfig
 from src.recommendation_models import OcrEvidence, OcrLine
+
+from config import OCR_MODEL_ROOT
 
 
 class OcrUnavailableError(RuntimeError):
     pass
+
+
+def _recommended_threads() -> int:
+    """按机器实际情况推荐 OpenMP/MKL 线程数。
+
+    优先取物理核数（超线程对 paddle CPU 推理基本无收益，用满会与
+    游戏/盒子抢核）；无法取到时按逻辑核折半。下限取配置
+    ocr_thread_min（默认 4）。
+    """
+    minimum = RecommendationConfig().ocr_thread_min
+    try:
+        import psutil
+        physical = psutil.cpu_count(logical=False)
+        if physical:
+            return max(minimum, int(physical))
+    except Exception:
+        pass
+    logical = os.cpu_count() or minimum
+    return max(minimum, logical // 2)
 
 
 def _external_click_module():
@@ -45,16 +68,37 @@ class PaddleOcrAdapter:
         self.engine = engine
         self.clock = clock
         self.engine_factory = engine_factory
-        default_root = (Path(os.environ.get("LOCALAPPDATA", Path.home()))
-                        / "AutoHS" / "ocr_models" / "paddleocr")
+        # 每次 OCR 的输入图按顺序存盘（会话子目录，便于调试查看到底
+        # 识别了多大的图）。优先级：
+        #   1. 环境变量 OCR_FRAME_DIR
+        #   2. config.ocr_frame_dump_dir（可清空关闭）
+        frame_root = os.environ.get(
+            "OCR_FRAME_DIR", RecommendationConfig().ocr_frame_dump_dir)
+        self._frame_counter = 0
+        self._frame_dir = None
+        if frame_root and frame_root != "0":
+            run_dir = Path(frame_root) / time.strftime("run_%H%M%S")
+            run_dir.mkdir(parents=True, exist_ok=True)
+            self._frame_dir = run_dir
+            print(f"[OCR] 本会话自动保存截图: {run_dir}")
+        default_root = Path(OCR_MODEL_ROOT)
         self.model_root = Path(model_root or default_root).resolve()
 
     def load(self):
         if self.engine is not None:
             return self
         try:
-            project_click = sys.modules.get("click")
-            sys.modules["click"] = _external_click_module()
+            # Multi-threaded OpenMP inference (measured 4.5x faster than the
+            # single-threaded default on a 16-core machine). Threads adapt to
+            # the machine's physical core count; use setdefault so an
+            # explicit user override still wins.
+            threads = str(_recommended_threads())
+            os.environ.setdefault("OMP_NUM_THREADS", threads)
+            os.environ.setdefault("MKL_NUM_THREADS", threads)
+            print(f"[OCR] 推理线程 OMP={os.environ['OMP_NUM_THREADS']}")
+            # 注意：paddleocr 的构造/推理不调用 CLI 的 click API ——
+            # 项目同名 click.py 可直接复用，无需外部 PyPI click。
+            # （实测：隐藏 PyPI click 后 PaddleOCR 构造成功。）
             if self.engine_factory is None:
                 from paddleocr import PaddleOCR
                 self.engine_factory = PaddleOCR
@@ -77,6 +121,7 @@ class PaddleOcrAdapter:
 
     def recognize(self, image, frame_id, preprocessing):
         self.load()
+        started = time.perf_counter()
         try:
             raw = self.engine.ocr(image, cls=False)
         except Exception as exc:
@@ -94,6 +139,16 @@ class PaddleOcrAdapter:
             (point[1] for point in item.box), default=0.0))
         normalized = "\n".join(line.text for line in lines if line.text)
         confidence = min((line.confidence for line in lines), default=0.0)
+        height, width = image.shape[:2] if image is not None else (0, 0)
+        print(f"[OCR] 图 {width}x{height} 行 {len(lines)} 置信 {confidence:.2f} "
+              f"耗时 {(time.perf_counter() - started) * 1000:.0f}ms "
+              f"({preprocessing})")
+        if self._frame_dir is not None:
+            self._frame_counter += 1
+            safe_name = str(preprocessing or "frame").replace("/", "_")
+            cv2.imwrite(
+                str(self._frame_dir / f"{self._frame_counter:03d}_{safe_name}.png"),
+                image)
         return OcrEvidence(
             frame_id, self.clock(), tuple(lines), normalized, confidence,
             self.name, preprocessing)

--- a/src/ocr/preprocess.py
+++ b/src/ocr/preprocess.py
@@ -1,13 +1,23 @@
 """Versioned image preprocessing candidates for HSAng's dark panel."""
 
+import os
+
 import cv2
 import numpy as np
+
+from src.recommendation_config import RecommendationConfig
+
+# 缩放系数集中定义于 config（ocr_preprocess_scale），
+# 环境变量 OCR_PREPROCESS_SCALE 可临时覆盖。
+_SCALE = float(
+    os.environ.get("OCR_PREPROCESS_SCALE")
+    or RecommendationConfig().ocr_preprocess_scale)
 
 
 def iter_preprocess_recommendation(image: np.ndarray):
     """Generate OCR candidates lazily, stopping work after a successful one."""
     scaled = cv2.resize(
-        image, None, fx=3.0, fy=3.0, interpolation=cv2.INTER_CUBIC)
+        image, None, fx=_SCALE, fy=_SCALE, interpolation=cv2.INTER_CUBIC)
     yield "scaled_color_v1", scaled
     gray = cv2.cvtColor(scaled, cv2.COLOR_BGR2GRAY)
     clahe = cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8, 8)).apply(gray)

--- a/src/ocr/stable_reader.py
+++ b/src/ocr/stable_reader.py
@@ -11,12 +11,29 @@ class OcrRejectedError(RuntimeError):
 
 class StableRecommendationReader:
     def __init__(self, config, backend, sleep=time.sleep,
-                 text_normalizer=None, required_headers=()):
+                 text_normalizer=None, required_headers=(), cache=None):
         self.config = config
         self.backend = backend
         self.sleep = sleep
         self.text_normalizer = text_normalizer or self._normalize
         self.required_headers = tuple(required_headers)
+        # Panel-pixel -> OCR evidence cache. Identical pixels always produce
+        # identical OCR output, so a frame whose exact hash was already
+        # recognized can skip the (expensive) inference entirely.
+        self._cache = {} if cache is None else cache
+
+    def _cached(self, frame):
+        """Reuse the OCR result for an unchanged panel, or None on miss."""
+        frame_hash = getattr(frame, "exact_hash", None)
+        if not frame_hash:
+            return None
+        evidence = self._cache.get(frame_hash)
+        if evidence is None:
+            return None
+        return type(evidence)(
+            frame.frame_id, time.time(), evidence.lines,
+            evidence.normalized_text, evidence.confidence,
+            evidence.backend, evidence.preprocessing)
 
     def read(self, frame_supplier, roi_supplier):
         previous_text = None
@@ -25,7 +42,12 @@ class StableRecommendationReader:
         for attempt in range(self.config.max_attempts):
             frame = frame_supplier()
             roi = roi_supplier(frame)
-            evidence = self._recognize_roi(roi, frame.frame_id)
+            evidence = self._cached(frame)
+            if evidence is None:
+                evidence = self._recognize_roi(roi, frame.frame_id)
+                frame_hash = getattr(frame, "exact_hash", None)
+                if evidence is not None and frame_hash:
+                    self._cache[frame_hash] = evidence
             if evidence is None:
                 previous_text = None
                 stable_count = 0
@@ -47,7 +69,12 @@ class StableRecommendationReader:
         raise OcrRejectedError("recommendation_not_stable")
 
     def read_frame(self, frame, roi_supplier):
-        evidence = self._recognize_roi(roi_supplier(frame), frame.frame_id)
+        evidence = self._cached(frame)
+        if evidence is None:
+            evidence = self._recognize_roi(roi_supplier(frame), frame.frame_id)
+            frame_hash = getattr(frame, "exact_hash", None)
+            if evidence is not None and frame_hash:
+                self._cache[frame_hash] = evidence
         if evidence is None:
             raise OcrRejectedError("recommendation_not_confident")
         return evidence

--- a/src/recommendation_config.py
+++ b/src/recommendation_config.py
@@ -1,17 +1,82 @@
-"""Conservative configuration for the first recommendation automation release."""
+"""推荐自动化全局配置（所有实测调优数值集中于此，附来源说明）。"""
 
+import json
 from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+def _user_roi() -> Optional[tuple[int, int, int, int]]:
+    """读取用户校准的推荐区域（ui_config.json 的 recommendation_roi）。
+
+    校准工具 calibrate_roi.py 把桌面上拖拽结果写入该文件；这里在每次创建
+    配置时应用（打包版/源码版路径一致：应用目录=src 的上级目录）。
+    未配置或格式非法时返回 None 走默认值。
+    """
+    try:
+        cfg_path = Path(__file__).resolve().parents[1] / "ui_config.json"
+        data = json.loads(cfg_path.read_text(encoding="utf-8"))
+        roi = data.get("recommendation_roi")
+        vals = tuple(int(v) for v in roi)
+        if len(vals) == 4 and 0 <= vals[0] < vals[2] and 0 <= vals[1] < vals[3]:
+            return vals
+    except Exception:
+        pass
+    return None
 
 
 @dataclass(frozen=True)
 class RecommendationConfig:
+    # ------------------------------------------------------------------ 屏幕
+    # 分辨率必须与炉石传说一致（程序校验用），DPI 100%.
     desktop_size: tuple[int, int] = (1920, 1080)
     desktop_dpi: int = 96
-    recommendation_roi: tuple[int, int, int, int] = (7, 32, 278, 970)
+
+    # 盒子面板完整区域（屏幕坐标 left, top, right, bottom）。
+    # 覆盖左侧推荐面板：宽 271，高 938。
+    recommendation_roi: tuple[int, int, int, int] = (7, 200, 202, 500)
+
+
+    # ------------------------------------------------------------------ 稳定帧
+    # 读取面板需连续 stable_frames 帧识别出相同文本才算稳（防动画中间帧）。
     max_attempts: int = 3
     stable_frames: int = 2
+    # 单行识别置信度低于该值即视为"读不清"重试。
     min_ocr_confidence: float = 0.70
     retry_interval_seconds: float = 0.1
-    mulligan_ready_delay_seconds: float = 20.0
+
+    # ------------------------------------------------------------------ 换牌
+    # 游戏开始后第 N 秒才开始换牌识图（盒子留牌面板此刻已就位）。
+    mulligan_ready_delay_seconds: float = 7.0
+    # 换牌识别成功到实际点击之间的缓冲（防止读错后立即点击，
+    # 也留出面板稳定时间）。
+    mulligan_post_ocr_delay_seconds: float = 5.0
+
+    # ------------------------------------------------------------------ 出牌
+    # 每个新回合开始延时一次（给盒子更新推荐留时间），
+    # 同回合内多次出牌操作之间不重复延时。
+    pre_action_delay_seconds: float = 7.0
+    # 一次操作执行完成之后到下轮截图+OCR 的延时（0 = 立即开始）；
+    # 配合上面"回合只延时一次"使用。
+    post_action_delay_seconds: float = 0.0
+    # 单次读取/单次执行的超时保护。
     recognition_timeout_seconds: float = 2.0
     result_timeout_seconds: float = 5.0
+
+    # ------------------------------------------------------------------ OCR
+    # 预处理缩放倍数：1.5x 是实测识别精度/速度最佳点
+    # （1.0x 快约 28% 但识别率下降不可接受；3.0x 无效且慢）。
+    # 仍可用环境变量 OCR_PREPROCESS_SCALE 临时覆盖。
+    ocr_preprocess_scale: float = 1.4
+    # 自动线程数下限：OpenMP/MKL 线程默认取机器物理核数，
+    # 低于此下限固定为此值（核数少的机器保守）。
+    ocr_thread_min: int = 4
+    # 调试用：每次 OCR 的实际输入图按顺序存盘目录（空 = 关闭）。
+    # 优先被环境变量 OCR_FRAME_DIR 覆盖。
+    ocr_frame_dump_dir: str = ""
+
+    def __post_init__(self) -> None:
+        # 校准工具写入的用户区域优先于代码默认值。
+        roi = _user_roi()
+        if roi is not None:
+            object.__setattr__(self, "recommendation_roi", roi)

--- a/tests/test_repeated_recommendation.py
+++ b/tests/test_repeated_recommendation.py
@@ -44,7 +44,7 @@ class SequencedCapture:
             frame("after", "after"),
         ))
 
-    def capture(self):
+    def capture(self, ocr_panel_ok=False):
         return next(self.frames)
 
     @staticmethod

--- a/web/index.html
+++ b/web/index.html
@@ -203,10 +203,19 @@ input:disabled{opacity:.45;cursor:not-allowed}
       <h2 class="card-title">🕹️ 对战控制</h2>
       <div class="btn-row big">
         <button id="btnStart" class="btn btn-primary btn-big" type="button">⚔️ 开始对战</button>
+        <button id="btnOverlay" class="btn" type="button">🪟 日志浮窗（关）</button>
         <button id="btnAfterGame" class="btn btn-warn" type="button" disabled>本局结束后停止</button>
         <button id="btnStopNow" class="btn btn-danger" type="button" disabled>立即停止</button>
       </div>
       <div class="hint-line">⌨️ 快捷键 Ctrl+Q 可随时立即停止自动化；请保持炉石与炉石盒子前台可见、分辨率 1920×1080、缩放 100%。</div>
+    </section>
+
+    <section class="card wide">
+      <h2 class="card-title">🎯 校准推荐区域</h2>
+      <div class="btn-row">
+        <button id="btnCalibrate" class="btn btn-ghost" type="button">📐 显示校准框</button>
+      </div>
+      <div class="hint-line">对战中启动：屏幕显示绿框（= 程序截图区域）+ 右侧实时 OCR 预览。拖动绿框使盒子的「打法参考A」面板对齐，识别到后点 [保存]（写入即生效，不覆盖名字/日志目录），Esc 退出。</div>
     </section>
 
     <section class="card wide">
@@ -479,7 +488,26 @@ $("btnCancelSched").addEventListener("click", function(){
   });
 });
 
+/* ---------- 校准推荐区域 ---------- */
+$("btnCalibrate").addEventListener("click", function(){
+  post("/api/calibrate", {}).then(function(r){
+    if (r.ok) toast(r.message, "ok");
+    else toast(r.error || "启动校准时失败", "error");
+  });
+});
+
 /* ---------- 对战控制 ---------- */
+$("btnOverlay").addEventListener("click", function(){
+  var btn = $("btnOverlay");
+  post("/api/overlay", {}).then(function(r){
+    if (r.ok) {
+      toast(r.message || (r.enabled ? "日志浮窗已开启" : "日志浮窗已关闭"), "ok");
+      btn.textContent = "🪟 日志浮窗（" + (r.enabled ? "开" : "关") + "）";
+    } else {
+      toast(r.error || "切换失败", "error");
+    }
+  });
+});
 $("btnStart").addEventListener("click", function(){
   var go = function(){
     $("btnStart").disabled = true;

--- a/web_ui.py
+++ b/web_ui.py
@@ -17,8 +17,14 @@
 from __future__ import annotations
 
 import ctypes
+try:
+    import log_overlay
+except Exception as exc:
+    print(f"[overlay] 导入日志浮窗失败(已禁用): {type(exc).__name__}: {exc}")
+    log_overlay = None
 import json
 import os
+import subprocess
 import sys
 import threading
 import time
@@ -33,9 +39,8 @@ from urllib.parse import parse_qs, urlparse
 ROOT = Path(__file__).resolve().parent
 WEB_DIR = ROOT / "web"
 CONFIG_PATH = ROOT / "ui_config.json"
-HOST = "127.0.0.1"
-BASE_PORT = 8765
-LOG_BUFFER_SIZE = 500
+# 站点/端口/日志缓冲来自 config.py（可通过环境变量覆盖，见 HS_HOST/HS_PORT/HS_LOG_BUFFER_SIZE）。
+from config import HOST, BASE_PORT, LOG_BUFFER_SIZE
 
 
 # ---------------------------------------------------------------- 管理员检测
@@ -92,6 +97,22 @@ def _log(level: str, msg: str):
             "level": level,
             "msg": str(msg),
         })
+    # 同时落盘：程序关闭/异常退出后仍可离线查看（诊断不依赖人工复制）。
+    try:
+        path = ROOT / "ui_log_last.txt"
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(f"{datetime.now().strftime('%Y-%m-%d %H:%M:%S')} "
+                    f"[{level}] {msg}\n")
+        if path.stat().st_size > 2 * 1024 * 1024:  # 只保留最近日志
+            lines = path.read_text(encoding="utf-8").splitlines()[-800:]
+            path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    except Exception:
+        pass
+
+
+def _overlay_key(line: str) -> bool:
+    keys = ("回合", "延时", "轮到己方", "等待", "[推荐]", "[执行]", "识别换牌")
+    return ("[OCR]" not in line) and any(k in line for k in keys)
 
 
 def take_logs_after(seq: int):
@@ -124,7 +145,10 @@ class _TeeStream:
                     break
             for line in text.splitlines():
                 if line.strip():
-                    _log(level, line.rstrip())
+                    s = line.rstrip()
+                    _log(level, s)
+                    if log_overlay is not None and _overlay_key(s):
+                        log_overlay.push(s, level)
 
     def flush(self):
         try:
@@ -250,6 +274,8 @@ def _start_automation():
 
 def _automation_worker(fsm):
     summary = {"games": 0, "wins": 0}
+    if log_overlay is not None:
+        log_overlay.start()
     # 自动化在后台线程运行；get_screen 等模块使用 win32com / win32ui（COM），
     # COM 要求线程级初始化，否则报“尚未调用 CoInitialize”并导致线程崩溃。
     com_ready = False
@@ -519,6 +545,30 @@ def api_schedule(body: dict):
     return {"ok": True, "message": "定时任务已设置，请保持本程序运行。"}
 
 
+def api_calibrate():
+    """启动推荐区域校准工具（绿框对齐，无实时 OCR 预览窗）。"""
+    script = ROOT / "calibrate_roi.py"
+    if not script.exists():
+        return {"ok": False, "error": f"校准工具缺失：{script}"}
+    try:
+        subprocess.Popen([sys.executable, str(script)], cwd=str(ROOT))
+    except Exception as exc:
+        return {"ok": False, "error": f"启动校准工具失败：{exc}"}
+    _log("SYS", "已启动推荐区域校准：拖绿框对齐盒子面板，按 S 保存，Esc 退出。")
+    return {"ok": True, "message": "校准工具已启动（无预览：拖绿框对齐盒子面板后按 S 保存，Esc 退出）"}
+
+
+def api_toggle_overlay(body=None):
+    """开/关右上角实时日志浮窗。"""
+    if log_overlay is None:
+        return {"ok": False, "error": "日志浮窗模块不可用"}
+    if log_overlay.is_running():
+        log_overlay.stop()
+        return {"ok": True, "enabled": False, "message": "日志浮窗已关闭"}
+    log_overlay.start()
+    return {"ok": True, "enabled": True, "message": "日志浮窗已开启"}
+
+
 def api_cancel_schedule():
     with CTRL.lock:
         if CTRL.automation_thread is not None:
@@ -681,6 +731,10 @@ class Handler(BaseHTTPRequestHandler):
                 self._json(api_schedule(body))
             elif path == "/api/schedule/cancel":
                 self._json(api_cancel_schedule())
+            elif path == "/api/calibrate":
+                self._json(api_calibrate())
+            elif path == "/api/overlay":
+                self._json(api_toggle_overlay(body))
             else:
                 self._json({"ok": False, "error": "未知接口"}, 404)
         except Exception as exc:


### PR DESCRIPTION
Bring the complete performance-tuned recommendation automation runtime (FSM_action, web_ui, main, config, src/flow, src/ocr, src/capture, src/game_state, src/parser, src/safety, web UI, constants, etc.) from the author's baseline onto this branch, so the whole speed/timing/OCR optimizations take effect instead of only config/OCR.

Excluded: fork-only extras (calibrate_roi.py, log_overlay.py) and repo README stays the author's.