### PR TITLE
自定义: 复位点(70,60) · 活人感(仅对局盒子意见后,悬停0.2~1s) · 浮窗品牌行与状态面板 · 投降检测可见性 · 恢复不…

### DIFF
--- a/FSM_action.py
+++ b/FSM_action.py
@@ -9,7 +9,9 @@ import keyboard
 
 import click
 import get_screen
-from config import DEFAULT_AUTO_CONCEDE, SNAPSHOT_WRITE_INTERVAL
+from config import (
+    DEFAULT_AUTO_CONCEDE, SNAPSHOT_WRITE_INTERVAL, human_like_settings,
+)
 from manual_controller import (
     ClickExecutor, GlobalHotkeyInput, ManualController,
 )
@@ -66,6 +68,9 @@ _mulligan_diagnostic_key = None
 _concede_streak = 0
 _concede_last_turn = None
 _concede_triggered = False
+# 供界面显示的最近一次检测结果（None = 本回合没读到/还没检测过）。
+_concede_last_rate = None
+_concede_last_check = None
 # 调试快照写盘节流：日志每次变化都全量序列化整个 log_state 会拖慢主循环，
 # 只在间隔 SNAPSHOT_WRITE_INTERVAL 秒后重新写盘。（定义于 config.py）
 _last_snapshot_write = 0.0
@@ -143,7 +148,8 @@ def initialize_recommendation_automation():
         # 上游时序：OCR 前的每局等待由 ChoosingCardAction 的 ready 延时负责；
         # OCR 成功后立即点击，不再叠加缓冲（mulligan_post_ocr_delay=0）。
         first_delay=recommendation_config.mulligan_post_ocr_delay_seconds,
-        retry_delay=recommendation_config.mulligan_post_ocr_delay_seconds)
+        retry_delay=recommendation_config.mulligan_post_ocr_delay_seconds,
+        post_action_pause=_human_like_post_action_pause)
     recommendation_flow = RecommendationFlow(
         capture=recommendation_capture,
         reader=recommendation_reader,
@@ -154,8 +160,30 @@ def initialize_recommendation_automation():
         controller=manual_controller,
         result_timeout=recommendation_config.result_timeout_seconds,
         post_action_delay=recommendation_config.post_action_delay_seconds,
+        post_action_pause=_human_like_post_action_pause,
         stopped=shutdown_event.is_set,
     )
+
+
+def _human_like_post_action_pause() -> bool:
+    """「活人感」延时：只在“对局中识别盒子意见并执行完”之后调用。
+
+    由 RecommendationFlow / MulliganFlow 在动作执行成功后调用，返回 True 表示
+    本次延时已被接管（随机 0.5~3s + 鼠标在手牌区悬停），流程层不再叠加固定延时。
+    未开启时返回 False，走原来的固定「操作后延时」。匹配对手、选卡组、错误弹窗
+    取消这类非推荐动作不会经过这里。
+    """
+    try:
+        if not human_like_settings().get("enabled"):
+            return False
+        click.human_like_pause()
+        return True
+    except Exception as exc:
+        try:
+            print(f"[SYS] 活人感延时失败，回退固定延时：{exc}")
+        except Exception:
+            pass
+        return False
 
 
 def reset_game_session():
@@ -165,6 +193,7 @@ def reset_game_session():
     global last_automation_diagnostic
     global _snapshot_cache_key, _snapshot_cache, _mulligan_diagnostic_key
     global _concede_streak, _concede_last_turn, _concede_triggered
+    global _concede_last_rate, _concede_last_check
     initialize_recommendation_automation()
     active_game_generation = log_state.game_generation
     choose_hero_count = 0
@@ -177,6 +206,8 @@ def reset_game_session():
     _concede_streak = 0
     _concede_last_turn = None
     _concede_triggered = False
+    _concede_last_rate = None
+    _concede_last_check = None
     click.center_mouse()
 
 
@@ -186,6 +217,7 @@ def init():
     global last_automation_diagnostic
     global _snapshot_cache_key, _snapshot_cache, _mulligan_diagnostic_key
     global _concede_streak, _concede_last_turn, _concede_triggered
+    global _concede_last_rate, _concede_last_check
 
     log_state = LogState()
     log_iter = log_iter_func(HEARTHSTONE_LOG_ROOT)
@@ -200,6 +232,8 @@ def init():
     _concede_streak = 0
     _concede_last_turn = None
     _concede_triggered = False
+    _concede_last_rate = None
+    _concede_last_check = None
     shutdown_event.clear()
     initialize_recommendation_automation()
     click.center_mouse()
@@ -632,6 +666,35 @@ def confirm_button_present() -> bool:
         for line in evidence.lines)
 
 
+# ---------------------------------------------------------------- 自动投降检测
+# 盒子浮动条“AI胜率 X%”的截图区域（1920x1080 实测）：主区域 + 放宽的兜底区域。
+_AI_WIN_RATE_REGIONS = ((110, 8, 270, 48), (95, 0, 300, 60))
+# 浮动条字号很小，放大后再送 OCR，识别率明显更高。
+_AI_WIN_RATE_SCALE = 2.0
+# 同一回合内 OCR 读不到时的重试次数与间隔：盒子浮动条常常要等面板画好才出现，
+# 只读一次就丢掉整个回合会表现为“有时候根本没在检测”。
+_CONCEDE_MAX_ATTEMPTS = 3
+_CONCEDE_RETRY_WAIT = 0.6
+
+
+def concede_detection_state() -> dict:
+    """自动投降检测的当前状态（供 Web 控制台 / 日志浮窗显示）。
+
+    rate=None 表示本回合没读到（或本局还没检测过）；checked_turn 是最近一次
+    检测发生在第几回合，用来直观确认“到底有没有在检测”。
+    """
+    cfg = _load_concede_config()
+    return {
+        "enabled": bool(cfg["enabled"]),
+        "threshold": float(cfg["threshold"]),
+        "rounds": int(cfg["rounds"]),
+        "rate": _concede_last_rate,
+        "streak": int(_concede_streak),
+        "checked_turn": _concede_last_check,
+        "triggered": bool(_concede_triggered),
+    }
+
+
 def _load_concede_config():
     """读取自动投降配置（ui_config.json 的 auto_concede 段）。"""
     try:
@@ -652,32 +715,45 @@ def _load_concede_config():
 
 
 def read_ai_win_rate():
-    """OCR 左上角盒子“AI胜率 X%”，返回百分数值；读不到返回 None。"""
+    """OCR 左上角盒子“AI胜率 X%”，返回百分数值；读不到返回 None。
+
+    浮动条字号很小，先放大再识别；主区域读不到时用放宽的兜底区域再试一次，
+    避免因为浮动条位置/宽度略有差异而整回合读不到。
+    """
     try:
         import cv2
         import numpy as np
         from PIL import ImageGrab
-        # 左上角盒子浮动条“AI胜率 49%”（1920x1080 实测区域）。
-        left, top, right, bottom = 110, 8, 270, 48
-        rgb = np.asarray(ImageGrab.grab(
-            bbox=(left, top, right, bottom), all_screens=False))
-        img = cv2.cvtColor(rgb, cv2.COLOR_RGB2BGR)
-        evidence = mulligan_reader.backend.recognize(
-            img, f"winrate-{time.time():.3f}", "winrate")
     except Exception:
         return None
-    for line in evidence.lines:
-        m = re.search(r"(\d+(?:\.\d+)?)\s*%", line.text)
-        if m:
-            value = float(m.group(1))
-            if 0.0 <= value <= 100.0:
-                return value
+    for index, box in enumerate(_AI_WIN_RATE_REGIONS):
+        try:
+            rgb = np.asarray(ImageGrab.grab(bbox=box, all_screens=False))
+            img = cv2.cvtColor(rgb, cv2.COLOR_RGB2BGR)
+            img = cv2.resize(img, None, fx=_AI_WIN_RATE_SCALE,
+                             fy=_AI_WIN_RATE_SCALE,
+                             interpolation=cv2.INTER_CUBIC)
+            evidence = mulligan_reader.backend.recognize(
+                img, f"winrate-{index}-{time.time():.3f}", "winrate")
+        except Exception:
+            continue
+        for line in evidence.lines:
+            m = re.search(r"(\d+(?:\.\d+)?)\s*%", line.text)
+            if m:
+                value = float(m.group(1))
+                if 0.0 <= value <= 100.0:
+                    return value
     return None
 
 
 def _maybe_concede(snapshot):
-    """每回合检测一次左上角 AI 胜率；连续低于阈值达到设定回合数则返回 True。"""
+    """每回合检测左上角 AI 胜率；连续低于阈值达到设定回合数则返回 True。
+
+    同一回合内 OCR 读不到会重试若干次：盒子浮动条往往要等面板画好才出现，
+    原先“一次读不到就丢掉整个回合”，会表现为“有时候根本没在检测”。
+    """
     global _concede_streak, _concede_last_turn, _concede_triggered
+    global _concede_last_rate, _concede_last_check
     if _concede_triggered:
         return False
     cfg = _load_concede_config()
@@ -686,13 +762,28 @@ def _maybe_concede(snapshot):
     turn = getattr(snapshot, "game_num_turns_in_play", 0)
     if turn == _concede_last_turn:
         return False  # 本回合已检测过
-    _concede_last_turn = turn
-    rate = read_ai_win_rate()
+    rate = None
+    for attempt in range(1, _CONCEDE_MAX_ATTEMPTS + 1):
+        rate = read_ai_win_rate()
+        if rate is not None:
+            break
+        if attempt < _CONCEDE_MAX_ATTEMPTS:
+            manual_controller.output(
+                f"[SYS] 自动投降检测：AI胜率没读到（第 {attempt}/"
+                f"{_CONCEDE_MAX_ATTEMPTS} 次），{_CONCEDE_RETRY_WAIT:.1f}s 后重试……")
+            time.sleep(_CONCEDE_RETRY_WAIT)
+    _concede_last_turn = turn  # 无论成败，本回合不再重复检测
+    _concede_last_rate = rate  # 供浮窗/网页显示（None = 本回合没读到）
+    _concede_last_check = turn
     if rate is None:
         # 读不到胜率（面板未就绪/OCR失败）：不激进投降，重置连续计数。
+        # 这里始终打日志，方便区分“没检测”与“检测了但没读到”。
+        manual_controller.output(
+            f"[SYS] 自动投降检测：本回合（第 {turn} 回合）AI胜率读取失败，"
+            f"已重试 {_CONCEDE_MAX_ATTEMPTS} 次，跳过本次检测。")
         if _concede_streak:
             manual_controller.output(
-                "[SYS] 自动投降检测：AI胜率读取失败，连续计数清零。")
+                "[SYS] 自动投降检测：连续计数清零。")
         _concede_streak = 0
         return False
     if rate < cfg["threshold"]:

--- a/click.py
+++ b/click.py
@@ -11,6 +11,7 @@ from contextlib import contextmanager
 from constants.constants import *
 from print_info import *
 from get_screen import *
+from config import human_like_settings
 
 
 #测试不同分辨率的点击效果，因为屏幕截取未支持不同分辨率，失败了
@@ -65,15 +66,79 @@ def rand_sleep(interval):
     time.sleep(base_time + rand_time)
 
 
+# 鼠标复位点（只移动、不点击的待命位）：屏幕左上角空白处。
+# 历史：最初 (480, 540) 每局结束后会停在牌组选择界面第二行第一个卡组上，
+# 复位后偶发误选中该卡组；用户最终指定 (70, 60) 作为待命点。
+MOUSE_RESET_POS = (70, 60)
+
+# ---------------------------------------------------------------- 活人感（可选）
+# 只在【对局中识别盒子意见并执行完之后】生效：由 RecommendationFlow / MulliganFlow
+# 在动作执行成功后经 FSM_action._human_like_post_action_pause() 调用本函数，
+# 用 0.5~3s 的随机“思考”延时代替固定延时，期间把手牌区当普通人类一样随手悬停
+# （每处约 1s），最后仍复位到 MOUSE_RESET_POS。
+# 匹配对手、选卡组、错误弹窗取消这类非推荐动作不会触发。
+# 开关与参数在 Web 控制台的「活人感」卡片里设置（ui_config.json 的 human_like 段）。
+HAND_HOVER_Y = 1000          # 手牌卡面所在高度（与 choose_card 用的 y 一致）
+HAND_HOVER_SIZES = (3, 8)    # 手牌张数未知，按常见张数取卡位
+
+
 def center_mouse(mouse=None):
-    """Move the pointer to the neutral screen center without clicking."""
+    """Move the pointer to the neutral reset point without clicking."""
     if mouse is None:
         mouse = Controller()
-    mouse.position = (480, 540)
+    mouse.position = MOUSE_RESET_POS
+
+
+def _random_hand_hover_point(last=None):
+    """在“看起来像手牌卡面”的位置里随机取一点（对齐 HAND_CARD_X 的卡位）。
+
+    只移动不点击，所以即使落点处没有牌也无害；尽量避开刚停过的那个点。
+    """
+    for _ in range(8):
+        size = random.randint(*HAND_HOVER_SIZES)
+        point = (random.choice(HAND_CARD_X[size]), HAND_HOVER_Y)
+        if point != last:
+            return point
+    return (960, HAND_HOVER_Y)
+
+
+def human_like_pause(mouse=None, settings=None):
+    """活人感延时：0.5~3s 随机等待，期间鼠标在手牌区随机悬停。
+
+    每处悬停时长同样随机（默认 0.2~1s，见 config.DEFAULT_HUMAN_LIKE）。
+    全程只移动、绝不点击；结束前复位到 MOUSE_RESET_POS。返回本次总延时（秒）。
+    """
+    cfg = settings or human_like_settings()
+    if mouse is None:
+        mouse = Controller()
+    total = random.uniform(cfg["post_delay_min"], cfg["post_delay_max"])
+    # 这句同时驱动浮窗底部的延时进度条（log_overlay 解析“延时 X s 后”取总时长），
+    # 措辞保持“延时 X.Xs 后”，剩下的文字会作为进度条下方的说明显示。
+    sys_print(f"[SYS] 活人感 延时 {total:.1f}s 后（手牌区随机悬停等待）")
+    deadline = time.monotonic() + total
+    last = None
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        point = _random_hand_hover_point(last)
+        mouse.position = point
+        last = point
+        hover = random.uniform(cfg["hover_min"], cfg["hover_max"])
+        time.sleep(min(hover, remaining))
+    center_mouse(mouse)
+    # 与固定延时一致的收尾标记：让浮窗进度条立刻清空、显示“延时：无”。
+    sys_print("[SYS] 延时结束")
+    return total
 
 
 def park_mouse(mouse=None):
-    """Honor the minimum action delay, then park without clicking."""
+    """Finish an action: honor the minimum delay, then park without clicking.
+
+    「活人感」的随机延时/手牌悬停**不在这里**：它只在对局中识别盒子意见并执行后
+    由流程层调用（RecommendationFlow / MulliganFlow 的 post_action_pause），
+    否则匹配对手、选卡组、错误弹窗取消这类非推荐动作也会被拖慢。
+    """
     time.sleep(0.1)
     center_mouse(mouse)
 

--- a/config.py
+++ b/config.py
@@ -131,6 +131,45 @@ DECK_DROP_HOLD_INTERVAL = float(_env("HS_DECK_DROP_HOLD_INTERVAL", "0.8"))
 #               避免开局一两次低胜率就误降。
 DEFAULT_AUTO_CONCEDE = {"enabled": False, "threshold": 10.0, "rounds": 3}
 
+# ---------------------------------------------------------------- 活人感（可选）
+# 开启后：每次操作结束不再是固定的“操作后延时 + 立即复位”，而是
+#   1. 用 post_delay_min ~ post_delay_max 的随机延时（默认 0.5~3.0s）；
+#   2. 延时期间鼠标在手牌区随机悬停，每处停留 hover_min ~ hover_max 秒
+#      （默认 0.2~1.0s，每次悬停单独随机），只移动、不点击；
+#   3. 最后仍然复位到 click.MOUSE_RESET_POS。
+# 真实值保存在 ui_config.json 的 human_like 段；这里提供默认值与读取函数。
+DEFAULT_HUMAN_LIKE = {
+    "enabled": False,
+    "post_delay_min": 0.5,
+    "post_delay_max": 3.0,
+    "hover_min": 0.2,
+    "hover_max": 1.0,
+}
+
+
+def human_like_settings() -> dict:
+    """读取 ui_config.json 的 human_like 段（每次调用都读文件，改完即时生效）。
+
+    缺字段/类型不对时回退默认值；数值做基本收敛，避免配置写坏导致异常。
+    """
+    cfg = dict(DEFAULT_HUMAN_LIKE)
+    data = _load_ui_config().get("human_like")
+    if isinstance(data, dict):
+        for key in cfg:
+            if data.get(key) is not None:
+                cfg[key] = data[key]
+    try:
+        cfg["enabled"] = bool(cfg["enabled"])
+        lo = max(0.0, float(cfg["post_delay_min"]))
+        hi = max(lo, float(cfg["post_delay_max"]))
+        h_lo = max(0.05, float(cfg["hover_min"]))
+        h_hi = max(h_lo, float(cfg["hover_max"]))
+        cfg["post_delay_min"], cfg["post_delay_max"] = lo, hi
+        cfg["hover_min"], cfg["hover_max"] = h_lo, h_hi
+    except (TypeError, ValueError):
+        return dict(DEFAULT_HUMAN_LIKE)
+    return cfg
+
 # ---------------------------------------------------------------- 日志 / 快照
 # 读取 Power.log 到尾部(EOF)后、等待下一新行的轮询间隔（秒）。
 # 原先 0.2s 且连续两次 EOF 才返回，静止时每轮阻塞 0.4s；缩短后主循环对

--- a/log_overlay.py
+++ b/log_overlay.py
@@ -37,7 +37,16 @@ ACCENT = "#4aa3ff"
 DANGER = "#e05e4b"
 WARN = "#d98a2e"
 OK = "#2ea06b"
+GOLD = "#e8b93b"
 DISABLED = "#394050"
+
+# 浮窗顶部品牌行：本项目大名 + 一行小字副标题（放在“自动化日志”标题之前）。
+BRAND_NAME = "HSLegendArriver"
+BRAND_SUB = "炉石传说 · 自动对战"
+# 状态圆点：功能开着 = 绿，关着 = 红，状态未知 = 灰。
+MARKER_ON = GREEN
+MARKER_OFF = DANGER
+MARKER_UNKNOWN = DIM
 
 
 def _turn_start(line: str) -> bool:
@@ -157,13 +166,74 @@ _IS_STOP_AFTER = None
 _IS_IN_GAME = None
 _SCORE = None
 _ON_EXIT = None
+_HUMAN_LIKE = None
+_CONCEDE_DETECT = None
+
+
+def human_like_row(info) -> dict:
+    """浮窗“活人感”状态行：{'marker','value','value_color','detail'}。
+
+    info 形如 {"enabled", "post_delay_min", "post_delay_max",
+    "hover_min", "hover_max"}；None / 取不到时显示“—”，表示无法确认。
+    """
+    if info is None:
+        return {"marker": MARKER_UNKNOWN, "value": "—", "value_color": DIM,
+                "detail": ""}
+    if not info.get("enabled"):
+        return {"marker": MARKER_OFF, "value": "关", "value_color": DIM,
+                "detail": ""}
+    lo, hi = info.get("post_delay_min"), info.get("post_delay_max")
+    h_lo, h_hi = info.get("hover_min"), info.get("hover_max")
+    detail = f"{lo:g}~{hi:g}s" if lo is not None and hi is not None else ""
+    if h_lo is not None and h_hi is not None:
+        detail += (" · " if detail else "") + f"悬停 {h_lo:g}~{h_hi:g}s"
+    return {"marker": MARKER_ON, "value": "开", "value_color": GREEN,
+            "detail": detail}
+
+
+def concede_detect_row(info) -> dict:
+    """浮窗“自动投降检测”状态行：{'marker','value','value_color','detail'}。
+
+    info 形如 {"enabled", "threshold", "rounds", "rate", "streak",
+    "checked_turn", "triggered"}；rate=None 表示该回合没读到胜率。
+    """
+    if info is None:
+        return {"marker": MARKER_UNKNOWN, "value": "—", "value_color": DIM,
+                "detail": ""}
+    if not info.get("enabled"):
+        return {"marker": MARKER_OFF, "value": "关", "value_color": DIM,
+                "detail": ""}
+    rounds = info.get("rounds") or 0
+    streak = info.get("streak") or 0
+    if info.get("triggered"):
+        return {"marker": MARKER_ON, "value": "已触发认输", "value_color": DANGER,
+                "detail": f"连续 {streak}/{rounds}"}
+    rate = info.get("rate")
+    if rate is None:
+        turn = info.get("checked_turn")
+        where = f"第 {turn} 回合" if turn else "本回合"
+        return {"marker": MARKER_ON, "value": "未读到", "value_color": WARN,
+                "detail": f"{where} · 连续 {streak}/{rounds}"}
+    threshold = info.get("threshold")
+    below = threshold is not None and float(rate) < float(threshold)
+    if threshold is None:
+        detail = f"连续 {streak}/{rounds}"
+    elif below:
+        detail = f"低于阈值 {float(threshold):.0f}% · 连续 {streak}/{rounds}"
+    else:
+        detail = f"阈值 {float(threshold):.0f}% · 连续 {streak}/{rounds}"
+    return {"marker": MARKER_ON,
+            "value": f"{float(rate):.0f}%",
+            "value_color": WARN if below else TEXT,
+            "detail": detail}
 
 
 def start(on_start=None, on_halt=None, is_running=None,
           on_stop_after=None, is_stop_after=None,
-          is_in_game=None, score_callback=None, on_exit=None) -> None:
+          is_in_game=None, score_callback=None, on_exit=None,
+          human_like_callback=None, concede_callback=None) -> None:
     global _ON_START, _ON_HALT, _IS_RUNNING, _ON_STOP_AFTER, _IS_STOP_AFTER
-    global _IS_IN_GAME, _SCORE, _ON_EXIT
+    global _IS_IN_GAME, _SCORE, _ON_EXIT, _HUMAN_LIKE, _CONCEDE_DETECT
     if _STARTED[0]:
         return
     _ON_START = on_start
@@ -174,6 +244,8 @@ def start(on_start=None, on_halt=None, is_running=None,
     _IS_IN_GAME = is_in_game
     _SCORE = score_callback
     _ON_EXIT = on_exit
+    _HUMAN_LIKE = human_like_callback
+    _CONCEDE_DETECT = concede_callback
     _STOP.clear()
     _STARTED[0] = True
     threading.Thread(target=_run, name="hs-log-overlay", daemon=True).start()
@@ -282,7 +354,8 @@ def _run() -> None:
         root.attributes("-alpha", 0.94)
         sw = root.winfo_screenwidth()
         sh = root.winfo_screenheight()
-        W, H = 292, 510
+        # 高度比原来高 40px：新增的品牌行不占掉日志区的高度。
+        W, H = 292, 550
         x = sw - W - 12
         y = 12
         root.geometry(f"{W}x{H}+{x}+{y}")
@@ -311,6 +384,16 @@ def _run() -> None:
             btn.bind("<Leave>", lambda _e, b=bg: btn.config(bg=b))
             return btn
 
+        # ---- 品牌行：本项目大名（放在“自动化日志”标题之前） ------------
+        brand = tk.Frame(root, bg=TITLE_BG)
+        brand.pack(fill="x")
+        tk.Label(brand, text=BRAND_NAME, bg=TITLE_BG, fg=GOLD,
+                 font=("Georgia", 13, "bold")).pack(pady=(9, 0))
+        tk.Label(brand, text=BRAND_SUB, bg=TITLE_BG, fg=DIM,
+                 font=("Microsoft YaHei", 8)).pack(pady=(1, 7))
+        tk.Frame(root, bg=GOLD, height=1).pack(fill="x", padx=10)
+        tk.Frame(root, bg=PANEL, height=1).pack(fill="x")
+
         # ---- header ----------------------------------------------------
         head = tk.Frame(root, bg=TITLE_BG)
         head.pack(fill="x")
@@ -326,7 +409,33 @@ def _run() -> None:
         score_label = tk.Label(root, text="📊 战绩： —", bg=TITLE_BG, fg=DIM,
                                font=("Microsoft YaHei", 9), anchor="w")
         score_label.pack(fill="x", padx=8, pady=(6, 0))
-        tk.Frame(root, bg=PANEL, height=1).pack(fill="x")
+        # ---- 状态面板：活人感 / 投降检测 ----------------------------
+        # 用 grid 对齐成两行两列（左：名称+状态值；右：参数/计数），比原先
+        # 一整行塞满括号文本更清爽，也不再依赖容易糊掉的 emoji 图标。
+        status = tk.Frame(root, bg=PANEL)
+        status.pack(fill="x")
+        status.columnconfigure(2, weight=1)
+
+        def _status_row(row_index, name_text):
+            marker = tk.Label(status, text="●", bg=PANEL, fg=DIM,
+                              font=("Segoe UI", 7))
+            marker.grid(row=row_index, column=0, sticky="w",
+                        padx=(10, 4), pady=2)
+            name = tk.Label(status, text=name_text, bg=PANEL, fg=DIM,
+                            font=("Microsoft YaHei", 8))
+            name.grid(row=row_index, column=1, sticky="w", pady=2)
+            value = tk.Label(status, text="—", bg=PANEL, fg=TEXT,
+                             font=("Microsoft YaHei", 8, "bold"))
+            value.grid(row=row_index, column=2, sticky="w", padx=(6, 0), pady=2)
+            detail = tk.Label(status, text="", bg=PANEL, fg=DIM,
+                              font=("Microsoft YaHei", 8))
+            detail.grid(row=row_index, column=3, sticky="e",
+                        padx=(6, 10), pady=2)
+            return marker, value, detail
+
+        hl_marker, hl_value, hl_detail = _status_row(0, "活人感")
+        cd_marker, cd_value, cd_detail = _status_row(1, "投降检测")
+        tk.Frame(root, bg=TITLE_BG, height=1).pack(fill="x")
 
         # ---- buttons ---------------------------------------------------
         btn_frame = tk.Frame(root, bg=BG)
@@ -508,6 +617,24 @@ def _run() -> None:
                              f"胜率 {rate_txt}{concede_txt}", fg=TEXT)
                 else:
                     score_label.config(text="📊 战绩： —", fg=DIM)
+            if _HUMAN_LIKE is not None:
+                try:
+                    hl_info = _HUMAN_LIKE()
+                except Exception:
+                    hl_info = None
+                row = human_like_row(hl_info)
+                hl_marker.config(fg=row["marker"])
+                hl_value.config(text=row["value"], fg=row["value_color"])
+                hl_detail.config(text=row["detail"])
+            if _CONCEDE_DETECT is not None:
+                try:
+                    cd_info = _CONCEDE_DETECT()
+                except Exception:
+                    cd_info = None
+                row = concede_detect_row(cd_info)
+                cd_marker.config(fg=row["marker"])
+                cd_value.config(text=row["value"], fg=row["value_color"])
+                cd_detail.config(text=row["detail"])
             with _LOCK:
                 delay = dict(_DELAY) if _DELAY is not None else None
             if delay is not None:

--- a/src/flow/mulligan_flow.py
+++ b/src/flow/mulligan_flow.py
@@ -21,7 +21,8 @@ class MulliganFlow:
     def __init__(self, executor, action_supplier, state_supplier,
                  action_context=None, stopped=lambda: False,
                  sleep=time.sleep, pre_action_delay=0.0,
-                 first_delay=None, retry_delay=None, confirm_ready=None):
+                 first_delay=None, retry_delay=None, confirm_ready=None,
+                 post_action_pause=None):
         self.executor = executor
         self.action_supplier = action_supplier
         self.state_supplier = state_supplier
@@ -33,6 +34,8 @@ class MulliganFlow:
         # 用于“先确认面板在再执行换牌”：按钮不在场就不点击，避免面板未
         # 就绪时盲点。典型实现见 FSM_action.confirm_button_present()。
         self.confirm_ready = confirm_ready
+        # 「活人感」（可选）：盒子留牌意见执行完之后的随机延时 + 手牌悬停。
+        self.post_action_pause = post_action_pause
         self._delay_done = False
         if action_context is None:
             from contextlib import nullcontext
@@ -87,6 +90,12 @@ class MulliganFlow:
                 for index in selected:
                     self.executor.replace_starting_card(index, count)
                 self.executor.commit_choose_card()
+            # 盒子留牌意见已执行：交给「活人感」（若开启）做随机延时 + 手牌悬停。
+            if self.post_action_pause is not None:
+                try:
+                    self.post_action_pause()
+                except Exception:
+                    pass
             return MulliganResult(MulliganStatus.CONFIRMED, selected)
         except Exception as exc:
             try:

--- a/src/flow/recommendation_flow.py
+++ b/src/flow/recommendation_flow.py
@@ -33,6 +33,7 @@ class RecommendationFlow:
                  clock=time.monotonic,
                  result_timeout=5.0, stopped=lambda: False,
                  consumed=None, post_action_delay=0.0,
+                 post_action_pause=None,
                  hand_animation_delay=None):
         self.capture = capture
         self.reader = reader
@@ -49,6 +50,10 @@ class RecommendationFlow:
         self.stopped = stopped
         self.consumed = consumed or ConsumedActionStore()
         self.post_action_delay = post_action_delay
+        # 「活人感」（可选）：盒子意见执行完后的随机延时 + 鼠标在手牌区悬停。
+        # 返回 True 表示已接管本次延时，就不再叠加固定的 post_action_delay。
+        # 只有走到这里的“识别盒子意见并执行完”的对局动作才会触发它。
+        self.post_action_pause = post_action_pause
         self.hand_animation_delay = (
             hand_animation_delay
             if hand_animation_delay is not None
@@ -109,7 +114,15 @@ class RecommendationFlow:
                                       "execution_failed")
             # 操作结束后延时再开始下一轮截图+OCR（盒子更新面板留时间）。
             # 通过 controller.output 推送延时行，让浮窗底部计时表显示该延时。
-            if self.post_action_delay:
+            # 「活人感」开启时由 post_action_pause 接管（随机 0.5~3s + 手牌悬停），
+            # 此时不再叠加固定延时。
+            paused = False
+            if self.post_action_pause is not None:
+                try:
+                    paused = bool(self.post_action_pause())
+                except Exception:
+                    paused = False
+            if not paused and self.post_action_delay:
                 output = getattr(self.controller, "output", None)
                 if output is not None:
                     try:

--- a/tests/test_auto_concede_detection.py
+++ b/tests/test_auto_concede_detection.py
@@ -1,0 +1,247 @@
+"""自动投降检测：每回合都要读到胜率，读不到要在同一回合内重试。
+
+回归背景：原先每回合只读一次，读不到就把整回合标记为“已检测”并清零连续计数，
+盒子浮动条还没画好时就表现为“有时候根本没在检测”。
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import FSM_action
+
+CONCEDE_CFG = {"enabled": True, "threshold": 20.0, "rounds": 3}
+
+
+class MaybeConcedeTests(unittest.TestCase):
+    def setUp(self):
+        self._saved = (FSM_action._concede_streak, FSM_action._concede_last_turn,
+                       FSM_action._concede_triggered)
+        FSM_action._concede_streak = 0
+        FSM_action._concede_last_turn = None
+        FSM_action._concede_triggered = False
+        self.logs = []
+
+    def tearDown(self):
+        (FSM_action._concede_streak, FSM_action._concede_last_turn,
+         FSM_action._concede_triggered) = self._saved
+
+    def _snapshot(self, turn):
+        return SimpleNamespace(game_num_turns_in_play=turn)
+
+    def _run(self, turn, rates, cfg=None, output=None):
+        """rates 为 read_ai_win_rate 依次返回的值（可含 None）。"""
+        seq = list(rates)
+        logs = self.logs
+
+        def fake_read():
+            return seq.pop(0) if seq else None
+
+        with (
+            patch.object(FSM_action, "_load_concede_config",
+                         return_value=dict(cfg or CONCEDE_CFG)),
+            patch.object(FSM_action, "read_ai_win_rate", side_effect=fake_read),
+            patch.object(FSM_action.manual_controller, "output",
+                         side_effect=(output or (lambda msg: logs.append(msg)))),
+            patch.object(FSM_action.time, "sleep"),
+        ):
+            result = FSM_action._maybe_concede(self._snapshot(turn))
+        return result
+
+    def test_retries_within_the_same_turn_until_a_value_is_read(self):
+        result = self._run(turn=3, rates=[None, None, 12.0])
+
+        self.assertFalse(result)
+        self.assertEqual(1, FSM_action._concede_streak)
+        self.assertEqual(3, FSM_action._concede_last_turn)
+        # 前两次失败各打一条重试日志，说明“确实在检测、只是没读到”
+        self.assertEqual(2, len([m for m in self.logs if "没读到" in m]))
+
+    def test_all_attempts_failing_skips_the_turn_and_logs_it(self):
+        result = self._run(turn=4, rates=[None, None, None])
+
+        self.assertFalse(result)
+        self.assertEqual(0, FSM_action._concede_streak)
+        self.assertEqual(4, FSM_action._concede_last_turn)
+        self.assertTrue(any("读取失败" in m for m in self.logs))
+        self.assertTrue(any("跳过本次检测" in m for m in self.logs))
+
+    def test_same_turn_is_only_checked_once(self):
+        calls = []
+
+        with (
+            patch.object(FSM_action, "_load_concede_config",
+                         return_value=dict(CONCEDE_CFG)),
+            patch.object(FSM_action, "read_ai_win_rate",
+                         side_effect=lambda: (calls.append(1), 30.0)[1]),
+            patch.object(FSM_action.manual_controller, "output"),
+        ):
+            FSM_action._maybe_concede(self._snapshot(5))
+            FSM_action._maybe_concede(self._snapshot(5))
+
+        self.assertEqual(1, len(calls))
+
+    def test_three_consecutive_low_turns_trigger_concede(self):
+        results = [self._run(turn=t, rates=[10.0]) for t in (1, 2, 3)]
+
+        self.assertEqual([False, False, True], results)
+        self.assertTrue(FSM_action._concede_triggered)
+        self.assertEqual(3, FSM_action._concede_streak)
+
+    def test_high_rate_resets_the_streak(self):
+        self._run(turn=1, rates=[10.0])
+        self.assertEqual(1, FSM_action._concede_streak)
+
+        self._run(turn=2, rates=[55.0])
+
+        self.assertEqual(0, FSM_action._concede_streak)
+        self.assertTrue(any("未低于阈值" in m for m in self.logs))
+
+    def test_failed_read_resets_the_streak_and_says_so(self):
+        self._run(turn=1, rates=[10.0])
+
+        self._run(turn=2, rates=[None, None, None])
+
+        self.assertEqual(0, FSM_action._concede_streak)
+        self.assertTrue(any("连续计数清零" in m for m in self.logs))
+
+    def test_disabled_config_never_reads(self):
+        calls = []
+
+        with (
+            patch.object(FSM_action, "_load_concede_config",
+                         return_value={"enabled": False, "threshold": 20.0,
+                                       "rounds": 3}),
+            patch.object(FSM_action, "read_ai_win_rate",
+                         side_effect=lambda: calls.append(1)),
+        ):
+            result = FSM_action._maybe_concede(self._snapshot(1))
+
+        self.assertFalse(result)
+        self.assertEqual([], calls)
+        self.assertIsNone(FSM_action._concede_last_turn)
+
+    def test_already_triggered_stops_checking(self):
+        FSM_action._concede_triggered = True
+        calls = []
+
+        with patch.object(FSM_action, "read_ai_win_rate",
+                          side_effect=lambda: calls.append(1)):
+            result = FSM_action._maybe_concede(self._snapshot(9))
+
+        self.assertFalse(result)
+        self.assertEqual([], calls)
+
+
+class ConcedeDetectionStateTests(unittest.TestCase):
+    """供界面显示的检测状态：最近胜率 / 连续计数 / 最近检测回合。"""
+
+    def setUp(self):
+        self._saved = (FSM_action._concede_streak, FSM_action._concede_last_turn,
+                       FSM_action._concede_triggered, FSM_action._concede_last_rate,
+                       FSM_action._concede_last_check)
+        FSM_action._concede_streak = 0
+        FSM_action._concede_last_turn = None
+        FSM_action._concede_triggered = False
+        FSM_action._concede_last_rate = None
+        FSM_action._concede_last_check = None
+
+    def tearDown(self):
+        (FSM_action._concede_streak, FSM_action._concede_last_turn,
+         FSM_action._concede_triggered, FSM_action._concede_last_rate,
+         FSM_action._concede_last_check) = self._saved
+
+    def test_state_reports_config_and_live_values(self):
+        FSM_action._concede_last_rate = 15.0
+        FSM_action._concede_last_check = 5
+        FSM_action._concede_streak = 2
+        FSM_action._concede_triggered = True
+
+        with patch.object(FSM_action, "_load_concede_config",
+                          return_value=dict(CONCEDE_CFG)):
+            state = FSM_action.concede_detection_state()
+
+        self.assertEqual({"enabled": True, "threshold": 20.0, "rounds": 3,
+                          "rate": 15.0, "streak": 2, "checked_turn": 5,
+                          "triggered": True}, state)
+
+    def test_successful_check_records_rate_and_turn(self):
+        with (
+            patch.object(FSM_action, "_load_concede_config",
+                         return_value=dict(CONCEDE_CFG)),
+            patch.object(FSM_action, "read_ai_win_rate", return_value=12.0),
+            patch.object(FSM_action.manual_controller, "output"),
+        ):
+            FSM_action._maybe_concede(SimpleNamespace(game_num_turns_in_play=3))
+            state = FSM_action.concede_detection_state()
+
+        self.assertEqual(12.0, state["rate"])
+        self.assertEqual(3, state["checked_turn"])
+
+    def test_failed_check_keeps_turn_but_no_rate(self):
+        with (
+            patch.object(FSM_action, "_load_concede_config",
+                         return_value=dict(CONCEDE_CFG)),
+            patch.object(FSM_action, "read_ai_win_rate", return_value=None),
+            patch.object(FSM_action.manual_controller, "output"),
+            patch.object(FSM_action.time, "sleep"),
+        ):
+            FSM_action._maybe_concede(SimpleNamespace(game_num_turns_in_play=4))
+            state = FSM_action.concede_detection_state()
+
+        self.assertIsNone(state["rate"])
+        self.assertEqual(4, state["checked_turn"])   # 检测过，只是没读到
+
+
+class WinRateReadTests(unittest.TestCase):
+    """OCR 读取：小字号放大 + 主区域读不到时用兜底区域。"""
+
+    def test_returns_none_when_dependencies_missing(self):
+        with patch.dict("sys.modules", {"cv2": None}):
+            self.assertIsNone(FSM_action.read_ai_win_rate())
+
+    def test_uses_the_fallback_region(self):
+        attempts = []
+
+        class FakeBackend:
+            def recognize(self, img, tag, kind):
+                attempts.append(tag)
+                if tag.startswith("winrate-0"):
+                    return SimpleNamespace(lines=())
+                return SimpleNamespace(lines=(SimpleNamespace(
+                    text="AI胜率 15%", confidence=0.9),))
+
+        class FakeCv2:
+            COLOR_RGB2BGR = 0
+            INTER_CUBIC = 2
+
+            @staticmethod
+            def cvtColor(img, code):
+                return img
+
+            @staticmethod
+            def resize(img, size, fx=None, fy=None, interpolation=None):
+                return img
+
+        fake_np = SimpleNamespace(asarray=lambda img: img)
+        fake_grab = SimpleNamespace(grab=lambda bbox, all_screens: "img")
+
+        with (
+            patch.dict("sys.modules", {
+                "cv2": FakeCv2,
+                "numpy": fake_np,
+                "PIL": SimpleNamespace(ImageGrab=fake_grab),
+                "PIL.ImageGrab": fake_grab,
+            }),
+            patch.object(FSM_action, "mulligan_reader",
+                         SimpleNamespace(backend=SimpleNamespace(
+                             recognize=FakeBackend().recognize))),
+        ):
+            value = FSM_action.read_ai_win_rate()
+
+        self.assertEqual(15.0, value)
+        self.assertEqual(2, len(attempts))       # 主区域失败后用了兜底区域
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_human_like.py
+++ b/tests/test_human_like.py
@@ -1,0 +1,370 @@
+"""活人感（可选）：操作后 0.5~3s 随机延时，期间鼠标在手牌区随机悬停（每处 1s）。"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import click as hearthstone_click
+import config
+
+
+class RecordingMouse:
+    """只记录事件，不真的动系统鼠标。"""
+
+    def __init__(self):
+        self.events = []
+
+    @property
+    def position(self):
+        return None
+
+    @position.setter
+    def position(self, value):
+        self.events.append(("position", value))
+
+    def press(self, button):
+        self.events.append(("press", button))
+
+    def release(self, button):
+        self.events.append(("release", button))
+
+    @property
+    def moves(self):
+        return [v for kind, v in self.events if kind == "position"]
+
+
+class FakeClock:
+    """把 time.sleep / time.monotonic 换成可控时钟，测试不用真的等秒。"""
+
+    def __init__(self):
+        self.now = 0.0
+        self.slept = []
+
+    def sleep(self, seconds):
+        self.slept.append(seconds)
+        self.now += seconds
+
+    def monotonic(self):
+        return self.now
+
+
+class HumanLikeSettingsTests(unittest.TestCase):
+    def _with_config(self, payload):
+        tmp = tempfile.TemporaryDirectory()
+        path = Path(tmp.name) / "ui_config.json"
+        if payload is not None:
+            path.write_text(json.dumps(payload), encoding="utf8")
+        return tmp, path
+
+    def test_defaults_when_section_missing(self):
+        tmp, path = self._with_config({"name": "x"})
+        try:
+            with patch.object(config, "CONFIG_PATH", path):
+                settings = config.human_like_settings()
+        finally:
+            tmp.cleanup()
+
+        self.assertEqual(config.DEFAULT_HUMAN_LIKE, settings)
+
+    def test_reads_saved_values(self):
+        tmp, path = self._with_config({"human_like": {
+            "enabled": True, "post_delay_min": 0.8,
+            "post_delay_max": 2.5, "hover_min": 0.3, "hover_max": 0.9}})
+        try:
+            with patch.object(config, "CONFIG_PATH", path):
+                settings = config.human_like_settings()
+        finally:
+            tmp.cleanup()
+
+        self.assertTrue(settings["enabled"])
+        self.assertEqual(0.8, settings["post_delay_min"])
+        self.assertEqual(2.5, settings["post_delay_max"])
+        self.assertEqual(0.3, settings["hover_min"])
+        self.assertEqual(0.9, settings["hover_max"])
+
+    def test_clamps_bad_numbers(self):
+        tmp, path = self._with_config({"human_like": {
+            "enabled": 1, "post_delay_min": -5,
+            "post_delay_max": -1, "hover_min": -3, "hover_max": 0}})
+        try:
+            with patch.object(config, "CONFIG_PATH", path):
+                settings = config.human_like_settings()
+        finally:
+            tmp.cleanup()
+
+        self.assertTrue(settings["enabled"])
+        self.assertEqual(0.0, settings["post_delay_min"])
+        self.assertEqual(0.0, settings["post_delay_max"])   # 上限不低于下限
+        self.assertEqual(0.05, settings["hover_min"])   # 悬停下限不为 0
+        self.assertEqual(0.05, settings["hover_max"])   # 上限不低于下限
+
+    def test_bad_types_fall_back_to_defaults(self):
+        tmp, path = self._with_config({"human_like": {
+            "enabled": True, "post_delay_min": "很快"}})
+        try:
+            with patch.object(config, "CONFIG_PATH", path):
+                settings = config.human_like_settings()
+        finally:
+            tmp.cleanup()
+
+        self.assertEqual(config.DEFAULT_HUMAN_LIKE, settings)
+
+
+class HumanLikePauseTests(unittest.TestCase):
+    def setUp(self):
+        self.clock = FakeClock()
+        self.mouse = RecordingMouse()
+        self.printed = []
+        self._patches = [
+            patch.object(hearthstone_click, "Controller", return_value=self.mouse),
+            patch.object(hearthstone_click.time, "sleep", self.clock.sleep),
+            patch.object(hearthstone_click.time, "monotonic", self.clock.monotonic),
+            patch.object(hearthstone_click, "sys_print",
+                         side_effect=lambda line: self.printed.append(line)),
+        ]
+        for item in self._patches:
+            item.start()
+
+    def tearDown(self):
+        for item in self._patches:
+            item.stop()
+
+    def _settings(self, lo=0.5, hi=3.0, h_lo=0.2, h_hi=1.0):
+        return {"enabled": True, "post_delay_min": lo,
+                "post_delay_max": hi, "hover_min": h_lo, "hover_max": h_hi}
+
+    @staticmethod
+    def _valid_hand_x():
+        xs = set()
+        for size in range(3, 9):
+            xs.update(hearthstone_click.HAND_CARD_X[size])
+        return xs
+
+    def test_random_pause_and_hovers(self):
+        # uniform 依次被调用：先取总延时，再为每处悬停取一次随机时长
+        with patch.object(hearthstone_click.random, "uniform",
+                          side_effect=[3.0, 1.0, 1.0, 1.0]):
+            total = hearthstone_click.human_like_pause(self.mouse, self._settings())
+
+        self.assertEqual(3.0, total)
+        moves = self.mouse.moves
+        # 3 处悬停 + 最后复位 1 次
+        self.assertEqual(4, len(moves))
+        self.assertEqual(hearthstone_click.MOUSE_RESET_POS, moves[-1])
+        valid_x = self._valid_hand_x()
+        for point in moves[:-1]:
+            x, y = point
+            self.assertEqual(hearthstone_click.HAND_HOVER_Y, y)
+            self.assertIn(x, valid_x)
+        # 每次悬停 1s（总时长刚好 3s）
+        self.assertEqual([1.0, 1.0, 1.0], self.clock.slept)
+        # 只移动，绝不点击
+        self.assertEqual([], [e for e in self.mouse.events if e[0] != "position"])
+        # 第一行是延时行（浮窗进度条靠它驱动），第二行是收尾标记（清空进度条）
+        self.assertEqual(2, len(self.printed))
+        self.assertIn("活人感 延时 3.0s 后", self.printed[0])
+        self.assertIn("延时结束", self.printed[1])
+
+    def test_short_pause_hovers_once(self):
+        with patch.object(hearthstone_click.random, "uniform",
+                          side_effect=[0.5, 1.0]):
+            total = hearthstone_click.human_like_pause(self.mouse, self._settings())
+
+        self.assertEqual(0.5, total)
+        moves = self.mouse.moves
+        self.assertEqual(2, len(moves))                       # 1 处悬停 + 复位
+        self.assertEqual(hearthstone_click.MOUSE_RESET_POS, moves[-1])
+        self.assertEqual([0.5], self.clock.slept)             # 只停到延时结束
+
+    def test_hover_duration_is_random_per_hover(self):
+        seq = [3.0, 0.2, 0.9, 0.5, 0.7, 0.3, 0.6, 0.4]
+        with patch.object(hearthstone_click.random, "uniform", side_effect=seq):
+            hearthstone_click.human_like_pause(self.mouse, self._settings())
+
+        sleeps = self.clock.slept
+        self.assertGreaterEqual(len(sleeps), 2)
+        self.assertGreater(len(set(sleeps)), 1,
+                           f"每处悬停时长应各自随机：{sleeps}")
+        for value in sleeps:
+            self.assertLessEqual(value, 1.0)      # 不超过设置的上限
+        self.assertAlmostEqual(3.0, self.clock.now, places=3)
+
+    def test_successive_hovers_prefer_different_slots(self):
+        with patch.object(hearthstone_click.random, "uniform",
+                          side_effect=[3.0, 1.0, 1.0, 1.0]):
+            hearthstone_click.human_like_pause(self.mouse, self._settings())
+
+        hovers = self.mouse.moves[:-1]
+        for before, after in zip(hovers, hovers[1:]):
+            self.assertNotEqual(before, after)
+
+
+class ParkMouseTests(unittest.TestCase):
+    """复位本身永远走“0.1s + 复位到左上角”，活人感不再挂在这里。
+
+    否则匹配对手、选卡组、错误弹窗取消这类非推荐动作也会被拖慢，
+    而活人感只应对局中识别盒子意见并执行完之后生效。
+    """
+
+    def test_park_is_plain_even_when_human_like_enabled(self):
+        mouse = RecordingMouse()
+        called = []
+
+        with (
+            patch.object(hearthstone_click, "human_like_settings",
+                         return_value={"enabled": True, "post_delay_min": 0.5,
+                                       "post_delay_max": 3.0,
+                                       "hover_min": 0.2, "hover_max": 1.0}),
+            patch.object(hearthstone_click, "human_like_pause",
+                         side_effect=lambda m=None, s=None: called.append(1)),
+            patch.object(hearthstone_click.time, "sleep") as sleep,
+        ):
+            hearthstone_click.park_mouse(mouse)
+
+        self.assertEqual([], called)                 # 不再自动触发活人感
+        sleep.assert_called_once_with(0.1)
+        self.assertEqual([("position", hearthstone_click.MOUSE_RESET_POS)],
+                         mouse.events)
+
+    def test_action_session_parks_plainly(self):
+        mouse = RecordingMouse()
+        called = []
+
+        with (
+            patch.object(hearthstone_click, "human_like_settings",
+                         return_value={"enabled": True}),
+            patch.object(hearthstone_click, "human_like_pause",
+                         side_effect=lambda m=None, s=None: called.append(1)),
+            patch.object(hearthstone_click, "Controller", return_value=mouse),
+            patch.object(hearthstone_click.time, "sleep"),
+        ):
+            with hearthstone_click.hearthstone_action_session():
+                pass
+
+        self.assertEqual([], called)
+        self.assertEqual([("position", hearthstone_click.MOUSE_RESET_POS)],
+                         mouse.events)
+
+
+class PostActionPauseHookTests(unittest.TestCase):
+    """FSM_action 的挂点：只在开启时接管，且只由流程层调用。"""
+
+    def setUp(self):
+        import FSM_action
+        self.fsm = FSM_action
+
+    def test_disabled_returns_false_and_does_not_pause(self):
+        calls = []
+        with (
+            patch.object(self.fsm, "human_like_settings",
+                         return_value={"enabled": False}),
+            patch.object(self.fsm.click, "human_like_pause",
+                         side_effect=lambda: calls.append(1)),
+        ):
+            handled = self.fsm._human_like_post_action_pause()
+
+        self.assertFalse(handled)
+        self.assertEqual([], calls)
+
+    def test_enabled_runs_pause_and_takes_over(self):
+        calls = []
+        with (
+            patch.object(self.fsm, "human_like_settings",
+                         return_value={"enabled": True}),
+            patch.object(self.fsm.click, "human_like_pause",
+                         side_effect=lambda: calls.append(1)),
+        ):
+            handled = self.fsm._human_like_post_action_pause()
+
+        self.assertTrue(handled)
+        self.assertEqual([1], calls)
+
+    def test_failure_falls_back_to_fixed_delay(self):
+        with (
+            patch.object(self.fsm, "human_like_settings",
+                         return_value={"enabled": True}),
+            patch.object(self.fsm.click, "human_like_pause",
+                         side_effect=RuntimeError("鼠标异常")),
+        ):
+            handled = self.fsm._human_like_post_action_pause()
+
+        self.assertFalse(handled)
+
+
+class WebHumanLikeTests(unittest.TestCase):
+    def setUp(self):
+        self._saved_thread = web_ui_thread()
+        import web_ui
+        self.web_ui = web_ui
+        self._saved = web_ui.CTRL.automation_thread
+
+    def tearDown(self):
+        self.web_ui.CTRL.automation_thread = self._saved
+
+    def test_status_exposes_defaults(self):
+        # 不能依赖用户真实的 ui_config.json：显式让 load_config 返回“没有 human_like 段”
+        with patch.object(self.web_ui, "load_config", return_value={}):
+            snapshot = self.web_ui.status_snapshot()
+        self.assertEqual(self.web_ui.DEFAULT_HUMAN_LIKE,
+                         {k: snapshot["human_like"][k]
+                          for k in self.web_ui.DEFAULT_HUMAN_LIKE})
+
+    def test_status_reflects_saved_section(self):
+        saved = {"human_like": {"enabled": True, "post_delay_min": 0.5,
+                                "post_delay_max": 3.0, "hover_min": 0.2, "hover_max": 1.0}}
+        with patch.object(self.web_ui, "load_config", return_value=saved):
+            snapshot = self.web_ui.status_snapshot()
+        self.assertTrue(snapshot["human_like"]["enabled"])
+
+    def test_refuses_while_running(self):
+        self.web_ui.CTRL.automation_thread = object()
+
+        result = self.web_ui.api_save_human_like({"enabled": True})
+
+        self.assertFalse(result["ok"])
+        self.assertIn("运行中", result["error"])
+
+    def test_saves_and_clamps(self):
+        saved = {}
+
+        with (
+            patch.object(self.web_ui, "load_config", return_value={}),
+            patch.object(self.web_ui, "save_config",
+                         side_effect=lambda cfg: saved.update(cfg)),
+            patch.object(self.web_ui, "_log"),
+            patch.object(self.web_ui.CTRL, "automation_thread", None),
+        ):
+            result = self.web_ui.api_save_human_like({
+                "enabled": True, "post_delay_min": 5, "post_delay_max": 1,
+                "hover_min": 1.5, "hover_max": 0.3})
+
+        self.assertTrue(result["ok"])
+        hl = saved["human_like"]
+        self.assertTrue(hl["enabled"])
+        self.assertEqual(5.0, hl["post_delay_min"])
+        self.assertEqual(5.0, hl["post_delay_max"])   # 上限被抬到不低于下限
+        self.assertEqual(1.5, hl["hover_min"])
+        self.assertEqual(1.5, hl["hover_max"])        # 悬停上限同样不低于下限
+        self.assertNotIn("hover_seconds", hl)         # 旧的固定悬停字段被清掉
+
+    def test_rejects_non_numeric(self):
+        with (
+            patch.object(self.web_ui, "load_config", return_value={}),
+            patch.object(self.web_ui.CTRL, "automation_thread", None),
+        ):
+            result = self.web_ui.api_save_human_like({"post_delay_min": "慢"})
+
+        self.assertFalse(result["ok"])
+        self.assertIn("数字", result["error"])
+
+
+def web_ui_thread():
+    """占位：保证 setUp 里先导入 web_ui 再取旧值。"""
+    import web_ui
+    return web_ui.CTRL.automation_thread
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_human_like_scope.py
+++ b/tests/test_human_like_scope.py
@@ -1,0 +1,197 @@
+"""活人感的生效范围：只在“对局中识别盒子意见并执行完”之后。
+
+- RecommendationFlow：出牌/攻击/技能等推荐动作执行成功后调用 post_action_pause；
+  返回 True 表示已接管延时，不再叠加固定「操作后延时」。
+- MulliganFlow：盒子留牌意见提交后同样调用一次。
+- 其他点击（匹配对手、选卡组、错误弹窗取消…）不经过这两个流程，因此不受影响
+  —— 见 tests/test_human_like.py 里的 park_mouse 测试。
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from manual_controller import ActionExecutionResult, EndTurnAction
+from src.flow.mulligan_flow import MulliganFlow, MulliganStatus
+from src.flow.recommendation_flow import FlowStepStatus, RecommendationFlow
+from src.game_state.recommendation_adapter import adapt_action
+from src.parser.recommendation_parser import RecommendationParser
+from src.recommendation_models import (
+    ActionKind, FrameEvidence, OcrEvidence,
+)
+from src.safety.recommendation_validator import RecommendationValidator
+
+
+def _frame(frame_id, exact_hash):
+    return FrameEvidence(
+        frame_id=frame_id, captured_at=0.0, desktop_size=(1920, 1080), dpi=96,
+        window_handle=1, foreground=True,
+        recommendation_roi=(7, 32, 278, 970), exact_hash=exact_hash,
+        perceptual_hash="0" * 64, panel_visible=True)
+
+
+def _evidence(frame_id, text):
+    return OcrEvidence(frame_id=frame_id, created_at=0.0, lines=(),
+                       normalized_text=text, confidence=0.90,
+                       backend="test", preprocessing="test")
+
+
+class SequencedCapture:
+    def __init__(self):
+        self.frames = iter((_frame("stable", "before"),
+                            _frame("current", "before"),
+                            _frame("after", "after")))
+
+    def capture(self, ocr_panel_ok=False):
+        return next(self.frames)
+
+    @staticmethod
+    def crop_recommendation(current_frame):
+        return current_frame
+
+
+class SequencedReader:
+    def __init__(self):
+        self.read_count = 0
+
+    def read(self, frame_supplier, _roi_supplier):
+        current_frame = frame_supplier()
+        self.read_count += 1
+        return _evidence(current_frame.frame_id,
+                         "结束回合" if self.read_count == 1 else "等待对手操作")
+
+    @staticmethod
+    def read_frame(current_frame, _roi_supplier):
+        return _evidence(current_frame.frame_id, "结束回合")
+
+
+class RecordingController:
+    def __init__(self):
+        self.actions = []
+
+    def execute(self, action, _state):
+        self.actions.append(action)
+        return ActionExecutionResult(True, "executed")
+
+
+class RecommendationPauseTests(unittest.TestCase):
+    def _run(self, hook):
+        active = SimpleNamespace(is_my_turn=True, game_num_turns_in_play=3)
+        ended = SimpleNamespace(is_my_turn=False, game_num_turns_in_play=4)
+        states = iter(((active, 10), (active, 10), (ended, 11)))
+        sleeps = []
+        flow = RecommendationFlow(
+            capture=SequencedCapture(),
+            reader=SequencedReader(),
+            parser=RecommendationParser(),
+            state_supplier=lambda: next(states),
+            adapter=adapt_action,
+            validator=RecommendationValidator(),
+            controller=RecordingController(),
+            sleep=sleeps.append,
+            post_action_delay=0.2,
+            post_action_pause=hook,
+        )
+        flow.waiting_instruction = "结束回合"
+        flow.waiting_panel_hash = "0" * 64
+        flow.waiting_turn_number = 3
+        flow.waiting_action_kind = ActionKind.END_TURN
+        result = flow.run_player_turn_step()
+        return result, sleeps
+
+    def test_hook_replaces_the_fixed_post_action_delay(self):
+        calls = []
+
+        result, sleeps = self._run(lambda: (calls.append(1), True)[1])
+
+        self.assertEqual(FlowStepStatus.EXECUTED, result.status)
+        self.assertEqual(1, len(calls))          # 推荐动作执行后调用了一次
+        self.assertNotIn(0.2, sleeps)            # 不再叠加固定延时
+
+    def test_disabled_hook_keeps_the_fixed_delay(self):
+        result, sleeps = self._run(lambda: False)
+
+        self.assertEqual(FlowStepStatus.EXECUTED, result.status)
+        self.assertIn(0.2, sleeps)
+
+    def test_hook_exception_does_not_break_the_step(self):
+        def boom():
+            raise RuntimeError("鼠标异常")
+
+        result, sleeps = self._run(boom)
+
+        self.assertEqual(FlowStepStatus.EXECUTED, result.status)
+        self.assertIn(0.2, sleeps)               # 异常时回退固定延时
+
+
+class _MulliganExecutor:
+    def __init__(self):
+        self.calls = []
+
+    def replace_starting_card(self, index, count):
+        self.calls.append(("replace", index, count))
+
+    def commit_choose_card(self):
+        self.calls.append(("commit",))
+
+    def cancel_click(self):
+        self.calls.append(("cancel",))
+
+
+def _card(card_id, entity_id):
+    return SimpleNamespace(card_id=card_id, entity_id=entity_id)
+
+
+class MulliganPauseTests(unittest.TestCase):
+    def _flow(self, hook):
+        cards = tuple(_card(f"CARD_{i}", i) for i in range(3))
+        state = SimpleNamespace(my_hand_cards=cards, is_end=False,
+                                game_num_turns_in_play=0)
+        action = SimpleNamespace(normalized_instruction="留牌1",
+                                 mulligan_slots=(1,))
+        executor = _MulliganExecutor()
+        flow = MulliganFlow(
+            executor=executor,
+            action_supplier=lambda: action,
+            state_supplier=lambda: state,
+            stopped=lambda: False,
+            first_delay=0.0,
+            retry_delay=0.0,
+            post_action_pause=hook,
+        )
+        return flow, executor
+
+    def test_pause_runs_after_mulligan_is_executed(self):
+        order = []
+
+        def hook():
+            order.append("pause")
+            return True
+
+        flow, executor = self._flow(hook)
+        original_commit = executor.commit_choose_card
+
+        def commit():
+            original_commit()
+            order.append("commit")
+
+        executor.commit_choose_card = commit
+
+        result = flow.run()
+
+        self.assertEqual(MulliganStatus.CONFIRMED, result.status)
+        self.assertEqual(["commit", "pause"], order)
+
+    def test_pause_exception_does_not_break_mulligan(self):
+        def boom():
+            raise RuntimeError("鼠标异常")
+
+        flow, executor = self._flow(boom)
+
+        result = flow.run()
+
+        self.assertEqual(MulliganStatus.CONFIRMED, result.status)
+        self.assertIn(("commit",), executor.calls)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mouse_reset_position.py
+++ b/tests/test_mouse_reset_position.py
@@ -1,0 +1,73 @@
+"""鼠标复位点：复位必须落在安全位置，且只移动、不点击。
+
+回归背景：旧的复位点 (480, 540) 每局结束后停在牌组选择界面第二行第一个卡组上，
+复位后偶发误选中卡组；用户最终指定屏幕左上角 (70, 60) 作为待命点。
+"""
+
+import unittest
+from unittest.mock import patch
+
+import click as hearthstone_click
+
+RESET = (70, 60)
+
+
+class RecordingMouse:
+    """只记录事件、不真的移动系统鼠标。"""
+
+    def __init__(self):
+        self.events = []
+
+    @property
+    def position(self):
+        return None
+
+    @position.setter
+    def position(self, value):
+        self.events.append(("position", value))
+
+    def press(self, button):
+        self.events.append(("press", button))
+
+    def release(self, button):
+        self.events.append(("release", button))
+
+
+class MouseResetPositionTests(unittest.TestCase):
+    def test_reset_position_is_the_safe_spot(self):
+        self.assertEqual(RESET, hearthstone_click.MOUSE_RESET_POS)
+
+    def test_center_mouse_only_moves_the_pointer(self):
+        mouse = RecordingMouse()
+
+        with patch.object(hearthstone_click, "Controller", return_value=mouse):
+            hearthstone_click.center_mouse()
+
+        self.assertEqual([("position", RESET)], mouse.events)
+
+    def test_park_mouse_moves_without_clicking(self):
+        mouse = RecordingMouse()
+
+        with (
+            patch.object(hearthstone_click, "Controller", return_value=mouse),
+            patch.object(hearthstone_click.time, "sleep"),
+        ):
+            hearthstone_click.park_mouse()
+
+        self.assertEqual([("position", RESET)], mouse.events)
+
+    def test_action_session_parks_at_the_safe_spot(self):
+        mouse = RecordingMouse()
+
+        with (
+            patch.object(hearthstone_click, "Controller", return_value=mouse),
+            patch.object(hearthstone_click.time, "sleep"),
+        ):
+            with hearthstone_click.hearthstone_action_session():
+                pass
+
+        self.assertEqual([("position", RESET)], mouse.events)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_overlay_human_like_status.py
+++ b/tests/test_overlay_human_like_status.py
@@ -1,0 +1,285 @@
+"""浮窗显示活人感开关状态 + 活人感延时驱动底部进度条。"""
+
+import inspect
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import log_overlay
+
+
+class _FakeThread:
+    def __init__(self, target=None, args=(), kwargs=None, **_ignored):
+        self._target = target
+        self._args = args
+
+    def start(self):
+        return None       # 不真的开 Tk 窗口
+
+
+class BrandHeaderTests(unittest.TestCase):
+    """浮窗顶部品牌行：本项目大名 + 副标题（排在“自动化日志”之前）。"""
+
+    def test_brand_name_and_subtitle(self):
+        self.assertEqual("HSLegendArriver", log_overlay.BRAND_NAME)
+        self.assertTrue(log_overlay.BRAND_SUB.strip())
+        self.assertTrue(log_overlay.GOLD.startswith("#"))
+
+    def test_marker_colors_are_green_red_gray(self):
+        self.assertEqual(log_overlay.GREEN, log_overlay.MARKER_ON)
+        self.assertEqual(log_overlay.DANGER, log_overlay.MARKER_OFF)
+        self.assertEqual(log_overlay.DIM, log_overlay.MARKER_UNKNOWN)
+
+
+class HumanLikeLabelTests(unittest.TestCase):
+    def test_unknown_state_shows_dash(self):
+        row = log_overlay.human_like_row(None)
+        self.assertEqual("—", row["value"])
+        self.assertEqual(log_overlay.MARKER_UNKNOWN, row["marker"])
+        self.assertEqual("", row["detail"])
+
+    def test_disabled_state(self):
+        row = log_overlay.human_like_row({"enabled": False})
+        self.assertEqual("关", row["value"])
+        self.assertEqual(log_overlay.MARKER_OFF, row["marker"])   # 关 = 红点
+
+    def test_enabled_state_shows_params(self):
+        row = log_overlay.human_like_row({
+            "enabled": True, "post_delay_min": 0.5, "post_delay_max": 3.0,
+            "hover_min": 0.2, "hover_max": 1.0})
+        self.assertEqual("开", row["value"])
+        self.assertEqual(log_overlay.GREEN, row["value_color"])
+        self.assertEqual(log_overlay.MARKER_ON, row["marker"])    # 开 = 绿点
+        self.assertIn("0.5~3s", row["detail"])
+        self.assertIn("悬停 0.2~1s", row["detail"])
+
+    def test_enabled_without_params(self):
+        row = log_overlay.human_like_row({"enabled": True})
+        self.assertEqual("开", row["value"])
+        self.assertEqual("", row["detail"])
+
+
+class ConcedeDetectLabelTests(unittest.TestCase):
+    def test_unknown_state(self):
+        row = log_overlay.concede_detect_row(None)
+        self.assertEqual("—", row["value"])
+        self.assertEqual(log_overlay.MARKER_UNKNOWN, row["marker"])
+
+    def test_disabled(self):
+        row = log_overlay.concede_detect_row({"enabled": False})
+        self.assertEqual("关", row["value"])
+        self.assertEqual(log_overlay.MARKER_OFF, row["marker"])   # 关 = 红点
+
+    def test_not_read_this_turn(self):
+        row = log_overlay.concede_detect_row({
+            "enabled": True, "threshold": 20.0, "rounds": 3, "rate": None,
+            "streak": 0, "checked_turn": 4, "triggered": False})
+        self.assertEqual("未读到", row["value"])
+        self.assertIn("第 4 回合", row["detail"])
+        self.assertIn("连续 0/3", row["detail"])
+        self.assertEqual(log_overlay.MARKER_ON, row["marker"])    # 开着 = 绿点
+        self.assertEqual(log_overlay.WARN, row["value_color"])
+
+    def test_below_threshold(self):
+        row = log_overlay.concede_detect_row({
+            "enabled": True, "threshold": 20.0, "rounds": 3, "rate": 15.4,
+            "streak": 2, "checked_turn": 5, "triggered": False})
+        self.assertEqual("15%", row["value"])
+        self.assertIn("低于阈值 20%", row["detail"])
+        self.assertIn("连续 2/3", row["detail"])
+        self.assertEqual(log_overlay.WARN, row["value_color"])
+
+    def test_above_threshold(self):
+        row = log_overlay.concede_detect_row({
+            "enabled": True, "threshold": 20.0, "rounds": 3, "rate": 64.0,
+            "streak": 0, "checked_turn": 5, "triggered": False})
+        self.assertEqual("64%", row["value"])
+        self.assertIn("阈值 20%", row["detail"])
+        self.assertNotIn("低于阈值", row["detail"])
+        self.assertEqual(log_overlay.TEXT, row["value_color"])
+        self.assertEqual(log_overlay.MARKER_ON, row["marker"])
+
+    def test_triggered(self):
+        row = log_overlay.concede_detect_row({
+            "enabled": True, "threshold": 20.0, "rounds": 3, "rate": 9.0,
+            "streak": 3, "checked_turn": 6, "triggered": True})
+        self.assertEqual("已触发认输", row["value"])
+        self.assertEqual(log_overlay.DANGER, row["value_color"])
+
+
+class StartWiringTests(unittest.TestCase):
+    def setUp(self):
+        self._started = log_overlay._STARTED[0]
+        self._human_like = log_overlay._HUMAN_LIKE
+        self._concede = log_overlay._CONCEDE_DETECT
+
+    def tearDown(self):
+        log_overlay._STARTED[0] = self._started
+        log_overlay._HUMAN_LIKE = self._human_like
+        log_overlay._CONCEDE_DETECT = self._concede
+
+    def test_start_accepts_human_like_callback(self):
+        self.assertIn("human_like_callback",
+                      inspect.signature(log_overlay.start).parameters)
+        callback = lambda: {"enabled": True}      # noqa: E731
+
+        with (
+            patch.object(log_overlay, "_run"),
+            patch.object(log_overlay.threading, "Thread", _FakeThread),
+        ):
+            log_overlay._STARTED[0] = False
+            log_overlay.start(human_like_callback=callback)
+
+        self.assertIs(callback, log_overlay._HUMAN_LIKE)
+
+    def test_start_accepts_concede_callback(self):
+        self.assertIn("concede_callback",
+                      inspect.signature(log_overlay.start).parameters)
+        callback = lambda: {"enabled": False}     # noqa: E731
+
+        with (
+            patch.object(log_overlay, "_run"),
+            patch.object(log_overlay.threading, "Thread", _FakeThread),
+        ):
+            log_overlay._STARTED[0] = False
+            log_overlay.start(concede_callback=callback)
+
+        self.assertIs(callback, log_overlay._CONCEDE_DETECT)
+
+
+class DelayBarTests(unittest.TestCase):
+    """活人感延时行必须能驱动浮窗底部进度条，并在结束时清空。"""
+
+    def setUp(self):
+        self._started = log_overlay._STARTED[0]
+        self._delay = log_overlay._DELAY
+        self._lines = list(log_overlay._LINES)
+        log_overlay._STARTED[0] = True
+        log_overlay._LINES.clear()
+
+    def tearDown(self):
+        log_overlay._STARTED[0] = self._started
+        log_overlay._DELAY = self._delay
+        log_overlay._LINES.clear()
+        log_overlay._LINES.extend(self._lines)
+
+    def test_human_like_delay_line_sets_progress_bar(self):
+        line = "[SYS] 活人感 延时 2.4s 后（手牌区随机悬停等待）"
+        self.assertIsNotNone(log_overlay._delay_start_re.search(line))
+
+        log_overlay.push(line, "SYS")
+
+        self.assertIsNotNone(log_overlay._DELAY)
+        self.assertAlmostEqual(2.4, log_overlay._DELAY["total"], places=3)
+        self.assertIn("活人感", log_overlay._DELAY["desc"])
+        self.assertIn("悬停", log_overlay._DELAY["desc"])
+
+    def test_delay_end_marker_clears_progress_bar(self):
+        log_overlay.push("[SYS] 活人感 延时 3.0s 后（手牌区随机悬停等待）", "SYS")
+        self.assertIsNotNone(log_overlay._DELAY)
+
+        log_overlay.push("[SYS] 延时结束", "SYS")
+
+        self.assertIsNone(log_overlay._DELAY)
+
+    def test_long_delay_line_also_stays_in_text_log(self):
+        """≥1s 的延时行除了驱动进度条，仍会出现在浮窗正文里（上游既有行为）。"""
+        log_overlay.push("[SYS] 活人感 延时 3.0s 后（手牌区随机悬停等待）", "SYS")
+
+        self.assertIsNotNone(log_overlay._DELAY)
+        self.assertIn("[SYS] 活人感 延时 3.0s 后（手牌区随机悬停等待）",
+                      [line for line, _turn in log_overlay._LINES])
+
+    def test_short_delay_line_only_drives_the_bar(self):
+        """<1s 的延时行只驱动进度条，不占浮窗正文（上游既有行为）。"""
+        line = "[SYS] 活人感 延时 0.5s 后（手牌区随机悬停等待）"
+        log_overlay.push(line, "SYS")
+
+        self.assertIsNotNone(log_overlay._DELAY)
+        self.assertNotIn(line, [text for text, _turn in log_overlay._LINES])
+
+
+class WebCallbackTests(unittest.TestCase):
+    def test_overlay_callback_reports_params(self):
+        import web_ui
+
+        with patch.object(web_ui, "_current_human_like", return_value={
+                "enabled": True, "post_delay_min": 0.5, "post_delay_max": 3.0,
+                "hover_min": 0.2, "hover_max": 1.0}):
+            info = web_ui._overlay_human_like()
+
+        row = log_overlay.human_like_row(info)
+        self.assertEqual("开", row["value"])
+        self.assertIn("0.5~3s", row["detail"])
+        self.assertIn("悬停 0.2~1s", row["detail"])
+
+    def test_overlay_callback_reports_disabled(self):
+        import web_ui
+
+        with patch.object(web_ui, "_current_human_like", return_value={
+                "enabled": False, "post_delay_min": 0.5, "post_delay_max": 3.0,
+                "hover_min": 0.2, "hover_max": 1.0}):
+            info = web_ui._overlay_human_like()
+
+        row = log_overlay.human_like_row(info)
+        self.assertEqual("关", row["value"])
+
+    def test_concede_state_prefers_live_fsm_values(self):
+        import web_ui
+
+        live = {"enabled": True, "threshold": 20.0, "rounds": 3, "rate": 15.0,
+                "streak": 2, "checked_turn": 5, "triggered": False}
+        fsm = SimpleNamespace(concede_detection_state=lambda: dict(live))
+
+        with patch.object(web_ui.CTRL, "fsm", fsm):
+            state = web_ui._concede_detect_state()
+
+        self.assertEqual(live, state)
+
+    def test_concede_state_falls_back_to_config(self):
+        import web_ui
+
+        with (
+            patch.object(web_ui.CTRL, "fsm", None),
+            patch.object(web_ui, "load_config", return_value={
+                "auto_concede": {"enabled": True, "threshold": 25.0,
+                                 "rounds": 4}}),
+        ):
+            state = web_ui._concede_detect_state()
+
+        self.assertTrue(state["enabled"])
+        self.assertEqual(25.0, state["threshold"])
+        self.assertEqual(4, state["rounds"])
+        self.assertIsNone(state["rate"])
+
+    def test_status_snapshot_exposes_detection_state(self):
+        import web_ui
+
+        live = {"enabled": True, "threshold": 20.0, "rounds": 3, "rate": 33.0,
+                "streak": 0, "checked_turn": 7, "triggered": False}
+        fsm = SimpleNamespace(concede_detection_state=lambda: dict(live),
+                              stop_after_current_game=False,
+                              FSM_state="Battling", game_count=1, win_count=1,
+                              concede_count=0)
+
+        with patch.object(web_ui.CTRL, "fsm", fsm):
+            snapshot = web_ui.status_snapshot()
+
+        self.assertEqual(live, snapshot["concede_detect"])
+
+    def test_overlay_concede_callback_returns_state(self):
+        import web_ui
+
+        with patch.object(web_ui, "_concede_detect_state",
+                          return_value={"enabled": True, "threshold": 20.0,
+                                        "rounds": 3, "rate": 10.0, "streak": 1,
+                                        "checked_turn": 2, "triggered": False}):
+            row = log_overlay.concede_detect_row(
+                web_ui._overlay_concede_detect())
+
+        self.assertEqual("10%", row["value"])
+        self.assertIn("连续 1/3", row["detail"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_overlay_resume_keeps_score.py
+++ b/tests/test_overlay_resume_keeps_score.py
@@ -1,0 +1,156 @@
+"""浮窗「恢复」续跑不得清零胜负战绩（中止 → 恢复 → 战绩继续累计）。
+
+回归背景：浮窗的「中止/恢复」是同一个按钮的开关；点「恢复」会走
+api_start → _start_automation，而它原先无条件把 game_count / win_count /
+concede_count 清零，导致一恢复战绩就归零。现在只有「开始对战」（重新开始）
+才清零，「恢复」保留已累计战绩。
+"""
+
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+import web_ui
+
+
+class _SyncThread:
+    """把 _start_automation 起的后台线程变成同步执行，便于断言。"""
+
+    def __init__(self, target=None, args=(), kwargs=None, **_ignored):
+        self._target = target
+        self._args = args
+        self._kwargs = kwargs or {}
+
+    def start(self):
+        if self._target is not None:
+            self._target(*self._args, **self._kwargs)
+
+    def join(self, timeout=None):
+        return None
+
+    def is_alive(self):
+        return False
+
+
+def _fake_fsm(game_count, win_count, concede_count):
+    """最小可用的 FSM_action 替身（不碰炉石、不点鼠标）。"""
+    module = types.ModuleType("FSM_action")
+    module.game_count = game_count
+    module.win_count = win_count
+    module.concede_count = concede_count
+    module.quitting_flag = False
+    module.stop_after_current_game = False
+    module.FSM_state = ""
+    module.time_begin = 0.0
+    module.print_info_init = lambda: None
+    module.init = lambda: None
+    module.AutoHS_automata = lambda: None
+    module.print_info_close = lambda: None
+    return module
+
+
+class OverlayHaltToggleTests(unittest.TestCase):
+    """浮窗「中止/恢复」按钮的分支。"""
+
+    def setUp(self):
+        self.calls = []
+        self._saved_thread = web_ui.CTRL.automation_thread
+
+    def tearDown(self):
+        web_ui.CTRL.automation_thread = self._saved_thread
+
+    def test_resume_asks_for_keep_score(self):
+        def fake_start(body):
+            self.calls.append(("start", body))
+            return {"ok": True}
+
+        def fake_stop(body):
+            self.calls.append(("stop", body))
+            return {"ok": True}
+
+        with (
+            patch.object(web_ui, "api_start", side_effect=fake_start),
+            patch.object(web_ui, "api_stop", side_effect=fake_stop),
+        ):
+            web_ui.CTRL.automation_thread = None
+            web_ui._overlay_halt()
+
+        self.assertEqual([("start", {"keep_score": True})], self.calls)
+
+    def test_halt_still_stops_immediately(self):
+        def fake_start(body):
+            self.calls.append(("start", body))
+            return {"ok": True}
+
+        def fake_stop(body):
+            self.calls.append(("stop", body))
+            return {"ok": True}
+
+        with (
+            patch.object(web_ui, "api_start", side_effect=fake_start),
+            patch.object(web_ui, "api_stop", side_effect=fake_stop),
+        ):
+            web_ui.CTRL.automation_thread = object()
+            web_ui._overlay_halt()
+
+        self.assertEqual([("stop", {"mode": "now"})], self.calls)
+
+
+class StartAutomationScoreTests(unittest.TestCase):
+    """_start_automation 的清零开关。"""
+
+    def setUp(self):
+        self._saved = (web_ui.CTRL.fsm, web_ui.CTRL.automation_thread,
+                       web_ui.CTRL.phase)
+
+    def tearDown(self):
+        (web_ui.CTRL.fsm, web_ui.CTRL.automation_thread,
+         web_ui.CTRL.phase) = self._saved
+
+    def _start(self, fake, reset_stats):
+        with (
+            patch.dict(sys.modules, {"FSM_action": fake}),
+            patch.object(web_ui, "load_config",
+                         return_value={"name": "TestUser#12345",
+                                       "log_root": "."}),
+            patch.object(web_ui, "_apply_constants"),
+            patch.object(web_ui, "_bind_overlay"),
+            patch.object(web_ui, "_stdout_capture_start"),
+            patch.object(web_ui, "_stdout_capture_stop"),
+            patch.object(web_ui, "_register_hotkey"),
+            patch.object(web_ui, "_remove_hotkey"),
+            patch.object(web_ui, "_log"),
+            patch.object(web_ui.threading, "Thread", _SyncThread),
+        ):
+            return web_ui._start_automation(reset_stats=reset_stats)
+
+    def test_resume_keeps_win_loss_counters(self):
+        fake = _fake_fsm(5, 3, 1)
+
+        ok, _msg = self._start(fake, reset_stats=False)
+
+        self.assertTrue(ok)
+        self.assertEqual((5, 3, 1), (fake.game_count, fake.win_count,
+                                     fake.concede_count))
+
+    def test_fresh_start_still_resets_counters(self):
+        fake = _fake_fsm(5, 3, 1)
+
+        ok, _msg = self._start(fake, reset_stats=True)
+
+        self.assertTrue(ok)
+        self.assertEqual((0, 0, 0), (fake.game_count, fake.win_count,
+                                     fake.concede_count))
+
+    def test_reset_score_zeroes_all_three_counters(self):
+        fake = _fake_fsm(9, 4, 2)
+
+        web_ui._reset_score(fake)
+
+        self.assertEqual((0, 0, 0), (fake.game_count, fake.win_count,
+                                     fake.concede_count))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_web_prepare_flow.py
+++ b/tests/test_web_prepare_flow.py
@@ -1,0 +1,150 @@
+"""点「开始运行」只做准备（开浮窗 + 切炉石前台），绝不自动开始对战。"""
+
+import types
+import unittest
+from unittest.mock import patch
+
+import web_ui
+
+
+class _SyncThread:
+    """把 api_prepare 起的前台切换线程变成同步执行，便于断言。"""
+
+    def __init__(self, target=None, args=(), kwargs=None, **_ignored):
+        self._target = target
+        self._args = args
+        self._kwargs = kwargs or {}
+
+    def start(self):
+        if self._target is not None:
+            self._target(*self._args, **self._kwargs)
+
+
+class PrepareTests(unittest.TestCase):
+    def setUp(self):
+        self._saved = (web_ui.CTRL.prepared, web_ui.CTRL.automation_thread,
+                       web_ui.CTRL.starting)
+
+    def tearDown(self):
+        (web_ui.CTRL.prepared, web_ui.CTRL.automation_thread,
+         web_ui.CTRL.starting) = self._saved
+
+    def test_prepare_never_starts_automation(self):
+        started, bound, foreground = [], [], []
+        overlay = types.SimpleNamespace(is_running=lambda: False)
+
+        with (
+            patch.object(web_ui, "log_overlay", overlay),
+            patch.object(web_ui, "api_start",
+                         side_effect=lambda body=None: started.append(body)),
+            patch.object(web_ui, "_bind_overlay", side_effect=lambda: bound.append(1)),
+            patch.object(web_ui, "_bring_hearthstone_foreground",
+                         side_effect=lambda: foreground.append(1)),
+            patch.object(web_ui.threading, "Thread", _SyncThread),
+            patch.object(web_ui, "_log"),
+        ):
+            web_ui.CTRL.automation_thread = None
+            web_ui.CTRL.starting = False
+            web_ui.CTRL.prepared = False
+            result = web_ui.api_prepare({})
+
+        self.assertTrue(result["ok"])
+        self.assertTrue(result["prepared"])
+        self.assertEqual([], started)          # 关键：没有自动开始对战
+        self.assertEqual(1, len(bound))        # 浮窗已开启
+        self.assertEqual(1, len(foreground))   # 已切炉石前台
+        self.assertTrue(web_ui.CTRL.prepared)
+
+    def test_prepare_skips_overlay_when_already_open(self):
+        bound = []
+        overlay = types.SimpleNamespace(is_running=lambda: True)
+
+        with (
+            patch.object(web_ui, "log_overlay", overlay),
+            patch.object(web_ui, "_bind_overlay", side_effect=lambda: bound.append(1)),
+            patch.object(web_ui, "_bring_hearthstone_foreground"),
+            patch.object(web_ui.threading, "Thread", _SyncThread),
+            patch.object(web_ui, "_log"),
+        ):
+            web_ui.CTRL.automation_thread = None
+            web_ui.CTRL.starting = False
+            web_ui.api_prepare({})
+
+        self.assertEqual([], bound)
+
+    def test_prepare_refused_while_running(self):
+        web_ui.CTRL.automation_thread = object()
+
+        result = web_ui.api_prepare({})
+
+        self.assertFalse(result["ok"])
+        self.assertIn("运行中", result["error"])
+
+    def test_prepare_refused_while_starting(self):
+        web_ui.CTRL.automation_thread = None
+        web_ui.CTRL.starting = True
+
+        result = web_ui.api_prepare({})
+
+        self.assertFalse(result["ok"])
+        self.assertIn("运行中", result["error"])
+
+    def test_status_exposes_prepared_flag(self):
+        web_ui.CTRL.prepared = False
+        self.assertFalse(web_ui.status_snapshot()["prepared"])
+        web_ui.CTRL.prepared = True
+        self.assertTrue(web_ui.status_snapshot()["prepared"])
+
+
+class StartAfterPrepareTests(unittest.TestCase):
+    """就绪之后再点「开始对战」仍然走原本的启动逻辑（不清零开关不变）。"""
+
+    def setUp(self):
+        self._saved = (web_ui.CTRL.prepared, web_ui.CTRL.automation_thread,
+                       web_ui.CTRL.starting)
+
+    def tearDown(self):
+        (web_ui.CTRL.prepared, web_ui.CTRL.automation_thread,
+         web_ui.CTRL.starting) = self._saved
+
+    def test_start_after_prepare_moves_to_playing(self):
+        fake = types.ModuleType("FSM_action")
+        fake.game_count, fake.win_count, fake.concede_count = 5, 3, 1
+        fake.quitting_flag = False
+        fake.stop_after_current_game = False
+        fake.FSM_state = ""
+        fake.time_begin = 0.0
+        fake.print_info_init = lambda: None
+        fake.init = lambda: None
+        fake.AutoHS_automata = lambda: None
+        fake.print_info_close = lambda: None
+
+        with (
+            patch.dict("sys.modules", {"FSM_action": fake}),
+            patch.object(web_ui, "load_config",
+                         return_value={"name": "TestUser#12345", "log_root": "."}),
+            patch.object(web_ui, "_apply_constants"),
+            patch.object(web_ui, "_bind_overlay"),
+            patch.object(web_ui, "_stdout_capture_start"),
+            patch.object(web_ui, "_stdout_capture_stop"),
+            patch.object(web_ui, "_register_hotkey"),
+            patch.object(web_ui, "_remove_hotkey"),
+            patch.object(web_ui, "_log"),
+            patch.object(web_ui.threading, "Thread", _SyncThread),
+        ):
+            web_ui.CTRL.automation_thread = None
+            web_ui.CTRL.starting = False
+            web_ui.CTRL.prepared = True
+            ok, _msg = web_ui._start_automation(reset_stats=True)
+
+        self.assertTrue(ok)
+        self.assertTrue(web_ui.CTRL.prepared)
+        # 就绪后真正开打走的是原启动逻辑（这里 fake 线程瞬间跑完，
+        # 所以最终回到 idle；关键是启动确实执行了且战绩按“重新开始”清零）
+        self.assertEqual((0, 0, 0), (fake.game_count, fake.win_count,
+                                     fake.concede_count))
+        self.assertIn(web_ui.CTRL.phase, ("playing", "idle"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/index.html
+++ b/web/index.html
@@ -41,6 +41,13 @@ body{
 .logo h1{font-family:Georgia,"Songti SC","SimSun",serif;font-size:23px;letter-spacing:1px;background:linear-gradient(90deg,#f7d97e,#d9a62e);-webkit-background-clip:text;background-clip:text;color:transparent}
 .logo p{font-size:12px;color:var(--muted);margin-top:2px}
 .header-right{display:flex;align-items:center;gap:14px;flex-wrap:wrap}
+/* ---------- 开源地址条（页面最醒目位置，紧贴顶栏） ---------- */
+.repo-bar{background:linear-gradient(90deg,rgba(232,185,59,.18),rgba(232,185,59,.07) 55%,transparent);border-bottom:1px solid var(--border)}
+.repo-bar-inner{max-width:1180px;margin:0 auto;padding:11px 20px;display:flex;align-items:center;gap:10px;flex-wrap:wrap}
+.repo-bar-label{color:var(--text);font-size:13.5px;font-weight:600}
+.repo-bar a.repo-link{font-family:Consolas,"Courier New",monospace;font-weight:700;font-size:15px;color:#241a05;background:linear-gradient(180deg,#f2cd66,#d9a62e);border:1px solid #8a6a1c;border-radius:999px;padding:6px 16px;text-decoration:none;box-shadow:0 4px 16px rgba(232,185,59,.28);transition:filter .15s,transform .15s}
+.repo-bar a.repo-link:hover{color:#241a05;border-color:#8a6a1c;filter:brightness(1.08);transform:translateY(-1px)}
+.repo-bar-note{color:var(--muted);font-size:12.5px}
 .clock{font-family:Consolas,monospace;color:var(--muted);font-size:13px;text-align:right;line-height:1.5}
 .pill{display:flex;align-items:center;gap:8px;padding:7px 15px;border-radius:999px;font-size:13px;font-weight:600;border:1px solid var(--border);background:var(--panel2)}
 .pill .dot{width:9px;height:9px;border-radius:50%;background:#8b8071;flex:none}
@@ -121,6 +128,8 @@ input:disabled{opacity:.45;cursor:not-allowed}
 .toast.out{opacity:0;transform:translateX(14px)}
 @keyframes slidein{from{opacity:0;transform:translateX(16px)}to{opacity:1}}
 .footer{text-align:center;color:#5c5344;font-size:12px;padding:18px 0 34px}
+a{color:var(--gold-bright);text-decoration:none;border-bottom:1px dashed rgba(247,217,126,.45)}
+a:hover{color:#fff3c9;border-bottom-color:#fff3c9}
 </style>
 </head>
 <body>
@@ -140,6 +149,15 @@ input:disabled{opacity:.45;cursor:not-allowed}
     </div>
   </div>
 </header>
+
+<!-- 开源项目地址：放在最醒目的位置（顶栏正下方通栏） -->
+<div class="repo-bar">
+  <div class="repo-bar-inner">
+    <span class="repo-bar-label">📦 本开源项目地址：</span>
+    <a class="repo-link" href="https://github.com/magicstrangelzb/HearthstoneLegendArriver" target="_blank" rel="noopener noreferrer">github.com/magicstrangelzb/HearthstoneLegendArriver</a>
+    <span class="repo-bar-note">（GPL-3.0 · 完全免费开源，仅用于技术研究与代码交流；觉得有用欢迎点个 ⭐）</span>
+  </div>
+</div>
 
 <div class="container">
   <div id="banners"></div>
@@ -208,7 +226,7 @@ input:disabled{opacity:.45;cursor:not-allowed}
         <button id="btnAfterGame" class="btn btn-warn" type="button" disabled>本局结束后停止</button>
         <button id="btnStopNow" class="btn btn-danger" type="button" disabled>立即停止</button>
       </div>
-      <div class="hint-line">⌨️ 快捷键 Ctrl+Q 可随时立即停止自动化；请保持炉石与炉石盒子前台可见、分辨率 1920×1080、缩放 100%。</div>
+      <div class="hint-line">🪄 点 <b>「开始运行」</b>只会打开日志浮窗、把炉石切到前台，<b>不会自动开打</b>；就绪后按钮变为 <b>「开始对战」</b>，再点一次（二次确认后）才真正开始。<br>⌨️ 快捷键 Ctrl+Q 可随时立即停止自动化；请保持炉石与炉石盒子前台可见、分辨率 1920×1080、缩放 100%。</div>
     </section>
 
     <section class="card wide">
@@ -231,6 +249,37 @@ input:disabled{opacity:.45;cursor:not-allowed}
         <button id="btnSaveConcede" class="btn btn-warn" type="button">💾 保存自动投降</button>
       </div>
       <div class="hint-line">检测左上角盒子「AI胜率」，连续 N 回合低于阈值时自动执行：右下角齿轮 → 中间红色「认输」。默认关闭，需手动开启；自动化运行中不可修改。</div>
+      <div class="hint-line" id="concedeDetect" style="margin-top:4px;color:var(--text)">检测状态：等待自动化运行…</div>
+    </section>
+
+    <section class="card wide">
+      <h2 class="card-title">🎭 活人感（可选）</h2>
+      <div class="input-row">
+        <label class="field" style="flex:none;min-width:90px">
+          <span class="field-label">启用</span>
+          <input id="chkHumanLike" type="checkbox" style="width:auto;height:22px">
+        </label>
+        <label class="field">
+          <span class="field-label">随机延时下限（秒）</span>
+          <input id="inpHlMin" type="number" min="0" max="60" step="0.1">
+        </label>
+        <label class="field">
+          <span class="field-label">随机延时上限（秒）</span>
+          <input id="inpHlMax" type="number" min="0" max="60" step="0.1">
+        </label>
+        <label class="field">
+          <span class="field-label">每处悬停下限（秒）</span>
+          <input id="inpHlHoverMin" type="number" min="0.05" max="30" step="0.05">
+        </label>
+        <label class="field">
+          <span class="field-label">每处悬停上限（秒）</span>
+          <input id="inpHlHoverMax" type="number" min="0.05" max="30" step="0.05">
+        </label>
+      </div>
+      <div class="btn-row">
+        <button id="btnSaveHumanLike" class="btn btn-ghost" type="button">💾 保存活人感</button>
+      </div>
+      <div class="hint-line">开启后：每次操作结束不再用固定的「操作后延时」，而是 <b>0.5~3 秒随机延时</b>；延时期间鼠标会在手牌区像真人一样随机悬停（每处 <b>0.2~1 秒随机</b>），最后仍复位到左上角。全程只移动、绝不点击，不影响出牌判定。日志浮窗会显示活人感开/关与投降检测状态，随机延时会显示在浮窗底部进度条上。默认关闭；自动化运行中不可修改，下一局开始时生效。</div>
     </section>
 
     <section class="card wide">
@@ -299,7 +348,7 @@ input:disabled{opacity:.45;cursor:not-allowed}
 
   </div>
 
-  <div class="footer">HSLegendArriver · 仅用于技术研究与代码交流</div>
+  <div class="footer">HSLegendArriver · 仅用于技术研究与代码交流 · <a href="https://github.com/magicstrangelzb/HearthstoneLegendArriver" target="_blank" rel="noopener noreferrer">github.com/magicstrangelzb/HearthstoneLegendArriver</a></div>
 </div>
 
 <div id="toasts"></div>
@@ -354,6 +403,7 @@ var logSeq = 0;
 var dirty = {name:false, log:false};
 var dirtyConcede = false;
 var dirtyDelays = false;
+var dirtyHumanLike = false;
 
 var PHASE_INFO = {
   idle:     {label:"空闲",            cls:"idle"},
@@ -403,7 +453,7 @@ function render(s){
   $("stRate").textContent = s.games > 0 ? s.win_rate + "%" : "--";
 
   $("btnStart").disabled = busy;
-  if (!s.starting) $("btnStart").textContent = "⚔️ 开始对战";
+  if (!s.starting) $("btnStart").textContent = s.prepared ? "⚔️ 开始对战" : "🪄 开始运行（准备）";
   $("btnAfterGame").disabled = !running || s.stop_after_game;
   $("btnStopNow").disabled = !running;
   $("btnSchedule").disabled = busy;
@@ -420,6 +470,43 @@ function render(s){
     $("chkConcede").checked = !!s.concede.enabled;
     $("inpConcedeThreshold").value = s.concede.threshold;
     $("inpConcedeRounds").value = s.concede.rounds;
+  }
+
+  /* 活人感 */
+  $("chkHumanLike").disabled = busy;
+  $("inpHlMin").disabled = busy;
+  $("inpHlMax").disabled = busy;
+  $("inpHlHoverMin").disabled = busy;
+  $("inpHlHoverMax").disabled = busy;
+  $("btnSaveHumanLike").disabled = busy;
+  if (s.human_like && !dirtyHumanLike){
+    $("chkHumanLike").checked = !!s.human_like.enabled;
+    $("inpHlMin").value = s.human_like.post_delay_min;
+    $("inpHlMax").value = s.human_like.post_delay_max;
+    $("inpHlHoverMin").value = s.human_like.hover_min;
+    $("inpHlHoverMax").value = s.human_like.hover_max;
+  }
+
+  /* 自动投降检测状态（每回合刷新，方便确认“到底有没有在检测”） */
+  var cd = s.concede_detect;
+  if (cd){
+    var det;
+    if (!cd.enabled){
+      det = "检测状态：已关闭";
+    } else if (cd.triggered){
+      det = "检测状态：已触发认输（连续 " + cd.streak + "/" + cd.rounds + " 回合）";
+    } else {
+      var turnTxt = cd.checked_turn ? " · 最近检测：第 " + cd.checked_turn + " 回合" : "";
+      if (cd.rate === null || cd.rate === undefined){
+        det = "检测状态：该回合未读到 AI胜率（连续 " + cd.streak + "/" + cd.rounds + " 回合）" + turnTxt;
+      } else {
+        var low = cd.rate < cd.threshold;
+        det = "检测状态：AI胜率 " + Number(cd.rate).toFixed(1) + "%"
+            + "（阈值 " + cd.threshold + "%，连续 " + cd.streak + "/" + cd.rounds + " 回合）"
+            + (low ? " ⚠️ 低于阈值" : " ✅ 未低于阈值") + turnTxt;
+      }
+    }
+    $("concedeDetect").textContent = det;
   }
 
   /* 延时设置 */
@@ -615,17 +702,24 @@ $("btnOverlay").addEventListener("click", function(){
   });
 });
 $("btnStart").addEventListener("click", function(){
+  /* 第一步：只做准备（开浮窗 + 切炉石前台），不自动开始对战。
+     就绪后按钮变成「开始对战」，再点一次（二次确认）才真正开始。 */
+  var prepared = !!(lastStatus && lastStatus.prepared);
   var go = function(){
     $("btnStart").disabled = true;
-    $("btnStart").textContent = "启动中…";
-    post("/api/start", {}).then(function(r){
+    $("btnStart").textContent = prepared ? "启动中…" : "准备中…";
+    post(prepared ? "/api/start" : "/api/prepare", {}).then(function(r){
       if (r.ok) toast(r.message, "ok");
-      else toast(r.error || "启动失败", "error");
+      else { toast(r.error || "操作失败", "error"); $("btnStart").disabled = false; }
     });
   };
+  if (!prepared){ go(); return; }
   if (lastStatus && lastStatus.phase === "waiting"){
-    if (confirm("当前有定时任务，立即开始对战将取消定时任务。确定继续？")) go();
-  } else go();
+    if (!confirm("当前有定时任务，立即开始对战将取消定时任务。确定继续？")) return;
+  } else if (!confirm("已就绪：确定开始自动对战？（脚本会开始匹配并自动打牌）")) {
+    return;
+  }
+  go();
 });
 
 $("btnAfterGame").addEventListener("click", function(){
@@ -660,6 +754,29 @@ $("btnSaveConcede").addEventListener("click", function(){
     if (r.ok){
       toast(r.message, "ok");
       dirtyConcede = false;
+    } else {
+      toast(r.error || "保存失败", "error");
+    }
+  });
+});
+
+/* ---------- 活人感 ---------- */
+$("chkHumanLike").addEventListener("change", function(){ dirtyHumanLike = true; });
+["inpHlMin","inpHlMax","inpHlHoverMin","inpHlHoverMax"].forEach(function(id){
+  $(id).addEventListener("input", function(){ dirtyHumanLike = true; });
+});
+
+$("btnSaveHumanLike").addEventListener("click", function(){
+  post("/api/human_like", {
+    enabled: $("chkHumanLike").checked,
+    post_delay_min: $("inpHlMin").value,
+    post_delay_max: $("inpHlMax").value,
+    hover_min: $("inpHlHoverMin").value,
+    hover_max: $("inpHlHoverMax").value
+  }).then(function(r){
+    if (r.ok){
+      toast(r.message, "ok");
+      dirtyHumanLike = false;
     } else {
       toast(r.error || "保存失败", "error");
     }

--- a/web_ui.py
+++ b/web_ui.py
@@ -41,7 +41,7 @@ WEB_DIR = ROOT / "web"
 CONFIG_PATH = ROOT / "ui_config.json"
 # 站点/端口/日志缓冲来自 config.py（可通过环境变量覆盖，见 HS_HOST/HS_PORT/HS_LOG_BUFFER_SIZE）。
 from config import (
-    DEFAULT_AUTO_CONCEDE, HOST, BASE_PORT, LOG_BUFFER_SIZE,
+    DEFAULT_AUTO_CONCEDE, DEFAULT_HUMAN_LIKE, HOST, BASE_PORT, LOG_BUFFER_SIZE,
     _USER_DELAY_KEYS, RecommendationConfig)
 
 
@@ -204,6 +204,8 @@ class _Controller:
         self.last_error = None
         self.last_summary = None
         self.hotkey_registered = False
+        # 已“就绪”（点过「开始运行」：浮窗已开 + 炉石已切前台，但还没真正开始对战）
+        self.prepared = False
 
 
 CTRL = _Controller()
@@ -240,7 +242,19 @@ def _persist_schedule(start_dt, end_dt):
 
 
 # ---------------------------------------------------------------- 自动化线程
-def _start_automation():
+def _reset_score(fsm):
+    """战绩清零：只有“重新开始”（网页/浮窗的「开始对战」）才调用。
+
+    浮窗的「恢复」是暂停→续跑，必须保留已累计的场数/胜场/认输数，
+    否则一按恢复战绩就归零（用户反馈）。
+    """
+    fsm.game_count = 0
+    fsm.win_count = 0
+    fsm.concede_count = 0
+
+
+def _start_automation(reset_stats: bool = True):
+    """启动自动化；reset_stats=False 表示浮窗「恢复」续跑，保留已有战绩。"""
     cfg = load_config()
     name = (cfg.get("name") or "").strip()
     log_root = (cfg.get("log_root") or "").strip()
@@ -252,14 +266,14 @@ def _start_automation():
         traceback.print_exc()
         return False, f"自动化组件加载失败：{exc}"
     fsm = CTRL.fsm
-    # 重置运行状态；每次“打开脚本/开始对战”时战绩清零，从 0 计。
+    # 重置运行状态；每次“打开脚本/开始对战”时战绩清零，从 0 计；
+    # 浮窗「恢复」续跑（reset_stats=False）不清零，从上次的场数/胜场继续累加。
     fsm.quitting_flag = False
     fsm.stop_after_current_game = False
     fsm.FSM_state = ""
     fsm.time_begin = 0.0
-    fsm.game_count = 0
-    fsm.win_count = 0
-    fsm.concede_count = 0
+    if reset_stats:
+        _reset_score(fsm)
     try:
         fsm.print_info_init()
         fsm.init()
@@ -270,7 +284,12 @@ def _start_automation():
     CTRL.last_summary = None
     CTRL.stopped_by = None
     CTRL.phase = "playing"
-    _log("SYS", f"自动化启动：用户 {name}，日志目录 {log_root}")
+    CTRL.prepared = True
+    if reset_stats:
+        _log("SYS", f"自动化启动：用户 {name}，日志目录 {log_root}（战绩从 0 开始）")
+    else:
+        _log("SYS", f"自动化恢复：用户 {name}，日志目录 {log_root}"
+                    f"（战绩继续累计：已完成 {int(getattr(fsm, 'game_count', 0) or 0)} 场）")
     if name and "#" not in name:
         _log("WARN", "用户 ID 未包含 #编号，可能无法识别己方玩家，建议填写完整战网昵称。")
     _stdout_capture_start()
@@ -493,6 +512,47 @@ def api_save_concede(body):
                         "threshold": threshold, "rounds": rounds}}
 
 
+# ------------------------------------------------------------------ 活人感（可选）
+def _current_human_like() -> dict:
+    """返回当前生效的活人感配置（默认值叠加 ui_config.json 的 human_like 段）。"""
+    cfg = dict(DEFAULT_HUMAN_LIKE)
+    saved = load_config().get("human_like")
+    if isinstance(saved, dict):
+        for key in cfg:
+            if saved.get(key) is not None:
+                cfg[key] = saved[key]
+    return cfg
+
+
+def api_save_human_like(body):
+    """保存活人感配置（ui_config.json 的 human_like 段）。"""
+    with CTRL.lock:
+        if CTRL.automation_thread is not None:
+            return {"ok": False, "error": "自动化运行中，请先停止后再修改活人感配置。"}
+        cfg = load_config()
+        hl = _current_human_like()
+        hl["enabled"] = bool(body.get("enabled", hl["enabled"]))
+        try:
+            lo = float(body.get("post_delay_min", hl["post_delay_min"]))
+            hi = float(body.get("post_delay_max", hl["post_delay_max"]))
+            h_lo = float(body.get("hover_min", hl["hover_min"]))
+            h_hi = float(body.get("hover_max", hl["hover_max"]))
+        except (TypeError, ValueError):
+            return {"ok": False, "error": "延时时长/悬停时长必须为数字。"}
+        lo = max(0.0, min(60.0, lo))
+        hi = max(lo, min(60.0, hi))
+        h_lo = max(0.05, min(30.0, h_lo))
+        h_hi = max(h_lo, min(30.0, h_hi))
+        hl.update({"post_delay_min": lo, "post_delay_max": hi,
+                   "hover_min": h_lo, "hover_max": h_hi})
+        hl.pop("hover_seconds", None)   # 旧的固定悬停字段不再使用
+        cfg["human_like"] = hl
+        save_config(cfg)
+    _log("SYS", f"活人感配置已保存：{'开启' if hl['enabled'] else '关闭'}"
+                f"（随机延时 {lo:.1f}~{hi:.1f}s，每处悬停 {h_lo:.1f}~{h_hi:.1f}s）。")
+    return {"ok": True, "message": "活人感配置已保存", "human_like": hl}
+
+
 # ------------------------------------------------------------------ 延时设置
 # 各延时字段的边界与默认值（默认值取自 RecommendationConfig，即上游时序）。
 _DELAY_BOUNDS = {
@@ -538,6 +598,10 @@ def api_save_delays(body):
 
 
 def api_start(body: dict):
+    body = body or {}
+    # 浮窗「恢复」续跑：keep_score=True 时保留已累计战绩（场数/胜场/认输数），
+    # 只有“重新开始”才从 0 计。
+    keep_score = bool(body.get("keep_score"))
     with CTRL.lock:
         if CTRL.automation_thread is not None or CTRL.starting:
             return {"ok": False, "error": "自动化已经在运行中。"}
@@ -553,17 +617,63 @@ def api_start(body: dict):
         # 手动开始会取消尚未开始的定时计划
         CTRL.schedule = {"start": None, "end": None}
     _persist_schedule(None, None)
-    _log("SYS", "收到启动请求，正在初始化自动化组件（首次启动可能较慢，请稍候）……")
+    if keep_score:
+        _log("SYS", "收到恢复请求，正在续跑自动化（战绩继续累计，不清零）……")
+    else:
+        _log("SYS", "收到启动请求，正在初始化自动化组件（首次启动可能较慢，请稍候）……")
 
     def _boot():
-        ok, msg = _start_automation()
+        ok, msg = _start_automation(reset_stats=not keep_score)
         if not ok:
             with CTRL.lock:
                 CTRL.last_error = msg
             _log("ERROR", msg)
 
     threading.Thread(target=_boot, name="hs-boot", daemon=True).start()
+    if keep_score:
+        return {"ok": True, "message": "正在恢复自动化（战绩继续累计），请稍候……"}
     return {"ok": True, "message": "正在启动自动化，请稍候……"}
+
+
+def _bring_hearthstone_foreground():
+    """把炉石切到最前台（未运行则先拉起战网）。
+
+    仅在“开始运行/就绪”时按需调用；COM 需要线程级初始化。
+    """
+    try:
+        import pythoncom
+        pythoncom.CoInitialize()
+    except Exception:
+        pass
+    try:
+        import click
+        click.enter_HS()
+    except Exception as exc:
+        _log("WARN", f"切换到炉石前台失败：{exc}")
+
+
+def api_prepare(body=None):
+    """「开始运行」第一步：开日志浮窗 + 把炉石切到前台，但【不】开始自动对战。
+
+    真正的对战由「开始对战」按钮（本接口返回 prepared=True 后按钮会变成它）
+    或浮窗的 ▶ 开始对战 触发，避免点一下就开始打牌。
+    """
+    with CTRL.lock:
+        if CTRL.automation_thread is not None or CTRL.starting:
+            return {"ok": False, "error": "自动化已经在运行中。"}
+        CTRL.prepared = True
+    if log_overlay is not None and not log_overlay.is_running():
+        try:
+            _bind_overlay()
+        except Exception as exc:
+            _log("WARN", f"开启日志浮窗失败：{exc}")
+    threading.Thread(target=_bring_hearthstone_foreground,
+                     name="hs-prepare", daemon=True).start()
+    _log("SYS", "已就绪：日志浮窗已开启、正在把炉石切到前台；未开始对战，"
+                "确认无误后再点「开始对战」。")
+    return {"ok": True, "prepared": True,
+            "message": "已就绪：浮窗已开、炉石已切前台（不会自动开始）。"
+                       "再点一次「开始对战」或浮窗的 ▶ 开始对战 才会真正开打。"}
 
 
 def api_stop(body: dict):
@@ -803,6 +913,45 @@ def _overlay_score():
     return _current_score()
 
 
+def _overlay_human_like():
+    """浮窗「活人感」状态行数据（是否开启 + 参数），由 log_overlay 渲染。"""
+    try:
+        hl = _current_human_like()
+    except Exception:
+        return None
+    return hl
+
+
+def _concede_detect_state():
+    """自动投降检测的显示状态。
+
+    自动化模块已加载时取实时值（最近读到的胜率 / 连续计数 / 最近检测回合），
+    否则用配置兜底，保证页面在未运行时也能显示“开/关 + 阈值 + 连续 N 回合”。
+    """
+    with CTRL.lock:
+        fsm = CTRL.fsm
+    if fsm is not None and hasattr(fsm, "concede_detection_state"):
+        try:
+            return fsm.concede_detection_state()
+        except Exception:
+            pass
+    cfg = dict(DEFAULT_AUTO_CONCEDE)
+    saved = load_config().get("auto_concede")
+    if isinstance(saved, dict):
+        cfg.update({k: v for k, v in saved.items() if v is not None})
+    return {"enabled": bool(cfg["enabled"]), "threshold": float(cfg["threshold"]),
+            "rounds": int(cfg["rounds"]), "rate": None, "streak": 0,
+            "checked_turn": None, "triggered": False}
+
+
+def _overlay_concede_detect():
+    """浮窗「投降检测」状态行（与 human_like 同一套回调机制）。"""
+    try:
+        return _concede_detect_state()
+    except Exception:
+        return None
+
+
 def _overlay_exit():
     """浮窗“退出脚本”按钮：先停止自动化，再退出整个脚本进程。"""
     try:
@@ -826,7 +975,8 @@ def _overlay_halt():
     if running:
         api_stop({"mode": "now"})
     else:
-        api_start({})
+        # 浮窗「恢复」= 暂停后继续：不清零胜负战绩，从上次的场数/胜场接着算。
+        api_start({"keep_score": True})
 
 
 def _bind_overlay():
@@ -844,6 +994,8 @@ def _bind_overlay():
         is_stop_after=_overlay_is_stop_after,
         is_in_game=_overlay_is_in_game,
         score_callback=_overlay_score,
+        human_like_callback=_overlay_human_like,
+        concede_callback=_overlay_concede_detect,
         on_exit=_overlay_exit,
     )
 
@@ -919,6 +1071,7 @@ def status_snapshot():
         stopped_by = CTRL.stopped_by
         hotkey_ok = CTRL.hotkey_registered
         starting = CTRL.starting
+        prepared = CTRL.prepared
     elapsed = int(time.time() - time_begin) if time_begin > 0 else 0
     win_rate = round(wins * 100.0 / games, 1) if games else 0.0
     return {
@@ -926,6 +1079,7 @@ def status_snapshot():
         "is_admin": IS_ADMIN,
         "running": running,
         "starting": starting,
+        "prepared": prepared,
         "phase": phase,
         "stopped_by": stopped_by,
         "stop_after_game": stop_after,
@@ -940,6 +1094,8 @@ def status_snapshot():
         "schedule_start": start_iso,
         "schedule_end": end_iso,
         "concede": cfg.get("auto_concede") or dict(DEFAULT_AUTO_CONCEDE),
+        "concede_detect": _concede_detect_state(),
+        "human_like": _current_human_like(),
         "delays": _current_delays(),
         "config": {"name": cfg.get("name", ""), "log_root": cfg.get("log_root", "")},
         "last_error": err,
@@ -1019,6 +1175,8 @@ class Handler(BaseHTTPRequestHandler):
                 self._json(api_save_config(body))
             elif path == "/api/start":
                 self._json(api_start(body))
+            elif path == "/api/prepare":
+                self._json(api_prepare(body))
             elif path == "/api/stop":
                 self._json(api_stop(body))
             elif path == "/api/schedule":
@@ -1031,6 +1189,8 @@ class Handler(BaseHTTPRequestHandler):
                 self._json(api_toggle_overlay(body))
             elif path == "/api/concede":
                 self._json(api_save_concede(body))
+            elif path == "/api/human_like":
+                self._json(api_save_human_like(body))
             elif path == "/api/delays":
                 self._json(api_save_delays(body))
             else:


### PR DESCRIPTION
…清零 · 开始运行只准备 · 开源地址声明

相对上游 187f05b 的本机个性化改动（合并为一次提交）：

1) click.py：鼠标复位点改为屏幕左上角 (70, 60)。原 (480,540) 每局结束后停在
   牌组选择界面第二行第一个卡组上，复位后偶发误选中该卡组。坐标提为常量
   MOUSE_RESET_POS，center_mouse / park_mouse / 动作收尾共用同一待命点。
2) 活人感（可选，默认关闭）：
   - config.py：DEFAULT_HUMAN_LIKE（enabled / post_delay_min~max / hover_min~max）与 human_like_settings()；旧的固定 hover_seconds 不再使用。
   - click.py：human_like_pause() 用 post_delay 随机（默认 0.5~3s）等待，期间按 手牌卡位随机悬停，每处停留 hover 随机（默认 0.2~1s，每处单独随机），只移动 不点击，末尾复位；延时行驱动浮窗底部进度条，结束打「延时结束」清空。
   - 生效范围严格限定为【对局中识别盒子意见并执行完之后】：RecommendationFlow 在 controller.execute 成功后、MulliganFlow 在留牌提交后调用 post_action_pause， 返回 True 时不再叠加固定的「操作后延时」；匹配对手、选卡组、进入战斗、错误 弹窗取消等非推荐动作不经过这两个流程。
   - Web 端「🎭 活人感」卡片（随机延时上下限 + 悬停上下限 + 保存）与 POST /api/human_like，运行中拒绝修改。 3) 自动投降检测修复 + 可见性（FSM_action.py / web_ui.py / log_overlay.py）：
   - read_ai_win_rate() 把小字号放大 2 倍再 OCR，主区域读不到时用放宽的兜底区域；
   - _maybe_concede() 同一回合内最多重试 3 次（间隔 0.6s），不再出现原来 「一次读不到就丢掉整个回合」的情况；无论读到还是没读到都打日志；
   - 新增 concede_detection_state()（最近胜率 / 连续计数 / 最近检测回合）， status.concede_detect 与浮窗状态行实时显示，网页「自动投降」卡片下方显示同一 状态。检测时机仍为只在我方回合（用户确认）。 4) log_overlay.py 浮窗改版：
   - 顶部新增品牌行：本项目大名 HSLegendArriver（Georgia 金色粗体）+ 一行小字 副标题「炉石传说 · 自动对战」，金色分隔线，排在「自动化日志」标题之前； 窗口高度 510 → 550，品牌行不占掉日志区。
   - 状态面板重做：原先「emoji + 整行括号文字」在小字号下 emoji 糊成方块、信息挤 在一起；改为 PANEL 底色 + grid 三列对齐（名称列 / 彩色状态值 / 右对齐参数）， 只用 ● 与 · 两个安全字符。
   - 圆点颜色按功能开关：开 = 绿（GREEN），关 = 红（DANGER），状态未知 = 灰。 例：● 活人感 开 0.5~3s · 悬停 0.2~1s ／ ● 投降检测 15% 低于阈值 20% · 连续 2/3 5) web_ui.py：浮窗「中止/恢复」为同一按钮，点「恢复」原先会无条件清零
   game_count/win_count/concede_count。现拆出 _reset_score()，仅「开始对战」
   （重新开始）清零；「恢复」传 keep_score=True 续跑，战绩继续累计。
6) web_ui.py + web/index.html：点网页「开始运行」只做准备（开日志浮窗 + 把炉石
   切到前台 + 初始化，api_prepare / status.prepared），不再自动开始对战；就绪后
   按钮变「开始对战」，再点一次并二次确认才真正开打（浮窗的 ▶ 开始对战 亦可）。
7) web/index.html：开源项目地址声明放在最醒目位置 —— 顶栏正下方的通栏金色地址条
   （📦 本开源项目地址 + 可点击链接 + GPL-3.0 与用途说明），页面底部 footer 再放
   一条小号同样的链接。
8) tests：新增 test_mouse_reset_position.py、test_overlay_resume_keeps_score.py、
   test_web_prepare_flow.py、test_human_like.py、test_human_like_scope.py、
   test_overlay_human_like_status.py、test_auto_concede_detection.py 七组回归测试，
   共 162 项全部通过。